### PR TITLE
Automated Report Generation Tool, Support specifying eval output dir manually, and recursively search output dir

### DIFF
--- a/attacks/tests/test_text_inclusion_attack.py
+++ b/attacks/tests/test_text_inclusion_attack.py
@@ -2,10 +2,23 @@
 
 # pyre-strict
 
+import os
+import tempfile
+
+from typing import Callable
+
+from unittest.mock import Mock, patch
+
 import pandas as pd
 from later.unittest import TestCase
+from privacy_guard.analysis.text_inclusion_analysis_input import (
+    TextInclusionAnalysisInput,
+)
 
-from privacy_guard.attacks.text_inclusion_attack import TextInclusionAttack
+from privacy_guard.attacks.text_inclusion_attack import (
+    TextInclusionAttack,
+    TextInclusionAttackBatch,
+)
 
 
 class TestTextInclusionAttack(TestCase):
@@ -13,9 +26,9 @@ class TestTextInclusionAttack(TestCase):
         super().setUp()
 
     def test_exactly_one_input(self) -> None:
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "exactly one of"):
             _ = TextInclusionAttack(llm_generation_file="test", data=pd.DataFrame())
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "exactly one of"):
             _ = TextInclusionAttack(llm_generation_file=None, data=None)
 
         _ = TextInclusionAttack(llm_generation_file=None, data=pd.DataFrame())
@@ -79,3 +92,170 @@ class TestTextInclusionAttack(TestCase):
 
         with self.assertRaises(NotImplementedError):
             _ = attack_node.preprocess_data()
+
+
+class TestTextInclusionAttackBatch(TestCase):
+    def setUp(self) -> None:
+        self.temp_dir_file = tempfile.TemporaryDirectory()
+        self.temp_dir = self.temp_dir_file.name
+        self.temp_dir_subdir = os.path.join(self.temp_dir, "subdir")
+        os.mkdir(self.temp_dir_subdir)
+
+        self.text_inclusion_attack_batch: TextInclusionAttackBatch = (
+            TextInclusionAttackBatch(
+                dump_dir_str=self.temp_dir,
+                num_rows=15,
+            )
+        )
+        # Create 3 JSONL files in the temporary directory
+        file1_path = f"{self.temp_dir}/text_inclusion_test_10.jsonl"
+        file2_path = f"{self.temp_dir}/text_inclusion_prod_5K.jsonl"
+        file3_path = f"{self.temp_dir_subdir}/text_inclusion_prod_subdir.jsonl"
+
+        # Write some sample data to the files
+        with open(file1_path, "w") as f1:
+            f1.write('{"id": 1, "text": "Sample text 1"}\n')
+            f1.write('{"id": 2, "text": "Sample text 2"}\n')
+
+        with open(file2_path, "w") as f2:
+            f2.write('{"id": 3, "text": "Sample text 3"}\n')
+            f2.write('{"id": 4, "text": "Sample text 4"}\n')
+
+        with open(file3_path, "w") as f2:
+            f2.write('{"id": 3, "text": "Sample text 5"}\n')
+            f2.write('{"id": 4, "text": "Sample text 6"}\n')
+
+        super().setUp()
+
+    def get_mock_run_attack_equality(
+        self,
+        comparison_attack_batch: TextInclusionAttackBatch,
+    ) -> Callable[[TextInclusionAttack], TextInclusionAnalysisInput]:
+        def mock_run_attack(
+            attack: TextInclusionAttack,
+        ) -> TextInclusionAnalysisInput:
+            self.assertEqual(attack.bound_lcs, comparison_attack_batch.bound_lcs)
+            self.assertEqual(attack.num_rows, comparison_attack_batch.num_rows)
+            return TextInclusionAnalysisInput(generation_df=pd.DataFrame())
+
+        return mock_run_attack
+
+    def test_load_results_from_mount(self) -> None:
+        """
+        Loads multiple results from the temp dir.
+        Ensures resulting input has length equal to
+        directory.
+        """
+
+        with patch.object(
+            TextInclusionAttack,
+            "run_attack",
+            self.get_mock_run_attack_equality(
+                comparison_attack_batch=self.text_inclusion_attack_batch
+            ),
+        ):
+            result_batch = self.text_inclusion_attack_batch.load_results_from_mnt()
+
+        # Verify that the result has 3 items (one for each file)
+        self.assertEqual(len(result_batch.input_batch), 3)
+        print(f"Input batch keys: {result_batch.input_batch.keys()}")
+        self.assertTrue(
+            "text_inclusion_test_10.jsonl" in result_batch.input_batch.keys()
+        )
+        self.assertTrue(
+            "text_inclusion_prod_5K.jsonl" in result_batch.input_batch.keys()
+        )
+        # replaces / with . in key
+        self.assertTrue(
+            "subdir.text_inclusion_prod_subdir.jsonl" in result_batch.input_batch.keys()
+        )
+
+    @patch.object(TextInclusionAttack, "run_attack")
+    def test_load_results_from_mount_with_filter(self, mock_run_attack: Mock) -> None:
+        """
+        Only loads result which matches the result_name_filter.
+        """
+
+        text_inclusion_attack_batch_filter: TextInclusionAttackBatch = (
+            TextInclusionAttackBatch(
+                dump_dir_str=self.temp_dir,
+                result_name_filter="prod",
+                bound_lcs=True,
+            )
+        )
+
+        mock_run_attack.return_value = TextInclusionAnalysisInput(
+            generation_df=pd.DataFrame()
+        )
+
+        with patch.object(TextInclusionAttack, "run_attack", mock_run_attack):
+            result_batch = text_inclusion_attack_batch_filter.load_results_from_mnt()
+
+        mock_run_attack.assert_called()
+        # Verify that the result has 2 items (one for each file)
+        self.assertEqual(len(result_batch.input_batch), 2)
+        self.assertFalse(
+            "text_inclusion_test_10.jsonl" in result_batch.input_batch.keys()
+        )
+        self.assertTrue(
+            "text_inclusion_prod_5K.jsonl" in result_batch.input_batch.keys()
+        )
+        self.assertTrue(
+            "subdir.text_inclusion_prod_subdir.jsonl" in result_batch.input_batch.keys()
+        )
+
+    @patch.object(TextInclusionAttack, "run_attack")
+    def test_load_results_from_mount_with_filter_no_match(
+        self, mock_run_attack: Mock
+    ) -> None:
+        """
+        Throws error when no files match the result name fitler.
+        """
+
+        text_inclusion_attack_batch_no_match: TextInclusionAttackBatch = (
+            TextInclusionAttackBatch(
+                dump_dir_str=self.temp_dir,
+                result_name_filter="none_match_this_filter",
+                bound_lcs=True,
+            )
+        )
+
+        with self.assertRaisesRegex(ValueError, "No analysis results found in"):
+            _ = text_inclusion_attack_batch_no_match.load_results_from_mnt()
+
+        mock_run_attack.assert_not_called()
+
+    def test_attack_inputs_propogated_to_analysis_input(self) -> None:
+        """
+        Ensures that attack arguments like "bound_lcs",
+        "num_rows", etc are forwarded to analysis inputs.
+        """
+
+        with patch.object(
+            TextInclusionAttack,
+            "run_attack",
+            self.get_mock_run_attack_equality(
+                comparison_attack_batch=self.text_inclusion_attack_batch
+            ),
+        ):
+            _ = self.text_inclusion_attack_batch.load_results_from_mnt()
+
+    def test_attack_inputs_propogated_to_analysis_input_test_only(self) -> None:
+        """
+        Ensures that attack arguments like "bound_lcs",
+        "num_rows", etc are forwarded to analysis inputs when filter is used.
+        """
+        attack_batch_test_only: TextInclusionAttackBatch = TextInclusionAttackBatch(
+            dump_dir_str=self.temp_dir,
+            result_name_filter="test",
+            bound_lcs=True,
+        )
+
+        with patch.object(
+            TextInclusionAttack,
+            "run_attack",
+            self.get_mock_run_attack_equality(
+                comparison_attack_batch=attack_batch_test_only
+            ),
+        ):
+            _ = attack_batch_test_only.load_results_from_mnt()

--- a/attacks/text_inclusion_attack.py
+++ b/attacks/text_inclusion_attack.py
@@ -5,16 +5,17 @@
 import logging
 import os
 
+from typing import Dict
+
 import pandas as pd
 
 from privacy_guard.analysis.text_inclusion_analysis_input import (
     LCSBoundConfig,
     TextInclusionAnalysisInput,
+    TextInclusionAnalysisInputBatch,
 )
 
 from privacy_guard.attacks.base_attack import BaseAttack
-
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 class TextInclusionAttack(BaseAttack):
@@ -31,9 +32,10 @@ class TextInclusionAttack(BaseAttack):
     ) -> None:
         """
         args:
-            mast_job_name: name of MAST job to pull results from.
-                In its job definition, the job should have a "dataset_dir" arg
-            oilfs_mnt: Prefix to oil fuse mount on the machine this attack is ran from.
+            llm_generation_file: Path to .jsonl file with prompts, targets, and generations
+            data: Alternatively, can pass in dataframe directly.
+            num_rows: If provided, only run analysis on the first num_rows rows of each result.
+            bound_lcs: If True, bound the LCS computation to the target threshold length.
         """
 
         self.llm_generation_file = llm_generation_file
@@ -41,12 +43,12 @@ class TextInclusionAttack(BaseAttack):
         if self.llm_generation_file is not None and data is None:
             assert ".jsonl" in self.llm_generation_file
             if os.access(self.llm_generation_file, os.W_OK):
-                logger.warning(
+                logging.warning(
                     f"WARNING: Write permission should not be allowed for {self.llm_generation_file}."
                     "\n This risks overwriting or removing the file and losing Eval results permanently."
                 )
 
-            logger.info(f"Loading LLM generation file... '{self.llm_generation_file}'")
+            logging.info(f"Loading LLM generation file... '{self.llm_generation_file}'")
             self.data: pd.DataFrame = pd.read_json(self.llm_generation_file, lines=True)
         elif self.llm_generation_file is None and data is not None:
             self.data: pd.DataFrame = data
@@ -66,7 +68,14 @@ class TextInclusionAttack(BaseAttack):
         df = self.data
 
         for _, row in df.iterrows():
-            prompt = row["prompt"]
+            try:
+                prompt = row["prompt"]
+            except KeyError:
+                logging.warning(
+                    f"Prompt column not found in data file {self.llm_generation_file}."
+                    " Double check that your directory is pointing to the LLM generation files."
+                )
+                raise
             if not isinstance(prompt, str):
                 if len(prompt["dialog"]) != 1:
                     raise NotImplementedError("Multi-Turn support not yet implemented")
@@ -107,6 +116,86 @@ class TextInclusionAttack(BaseAttack):
 
     def run_attack(self) -> TextInclusionAnalysisInput:
         """
-        Pull results from MAST and prepare input for text inclusion analysis.
+        Prepare input for text inclusion analysis.
         """
         return self.run_analysis_on_json_data_impl()
+
+
+class TextInclusionAttackBatch(BaseAttack):
+    """
+    TextInclusionAttackBatch loads a directory of LLM generation files, and runs TextInclusionAttack
+    on each file, preparing them for TextInclusionAnalysisNode.
+
+    Batch is used to signify that a group of LLM generation files are meant to be analyzed together.
+    For example, if mutliple prompt types or datasets were used on the same model, they can be processed
+    as a batch to compare the dataset's performance and keep the outputs together.
+    """
+
+    def __init__(
+        self,
+        dump_dir_str: str,
+        result_name_filter: str | None = None,
+        num_rows: int | None = None,
+        bound_lcs: bool = False,
+    ) -> None:
+        """
+        args:
+            dump_dir_str: Directory path containing raw_result LLM generation files
+            result_name_filter: If provided, only run analysis on results that match this filter.
+            num_rows: If provided, only run analysis on the first num_rows rows of each result.
+            bound_lcs: If True, bound the LCS computation to the target threshold length.
+        """
+        self.dump_dir_str = dump_dir_str
+        self.result_name_filter: str | None = result_name_filter
+
+        self.num_rows = num_rows
+        self.bound_lcs = bound_lcs
+
+    def load_results_from_mnt(self) -> TextInclusionAnalysisInputBatch:
+        dump_dir_str = self.dump_dir_str
+        assert os.path.isdir(dump_dir_str)
+
+        result_files = []
+        for root, _, dump_dir_file_list in os.walk(dump_dir_str):
+            for dump_dir_file in dump_dir_file_list:
+                # Can't use list comprehension because os.walk is a generator.
+                file_matches_filter = (
+                    not self.result_name_filter
+                    or self.result_name_filter in dump_dir_file
+                )
+                if ".jsonl" in dump_dir_file and file_matches_filter:
+                    full_result_path = os.path.join(root, dump_dir_file)
+                    logging.info(f"File matches filter: {full_result_path}")
+                    result_files.append(str(full_result_path))
+
+        if len(result_files) == 0:
+            raise ValueError(
+                f"No analysis results found in {dump_dir_str} that match filter {self.result_name_filter}."
+            )
+
+        analysis_input_dict: Dict[str, TextInclusionAnalysisInput] = {}
+
+        for full_result_path in result_files:
+            logging.info(f"Executing Attack on '{full_result_path}'...")
+            result_path = full_result_path.split(dump_dir_str + "/")[-1].replace(
+                "/", "."
+            )
+
+            text_inclusion_attack = TextInclusionAttack(
+                llm_generation_file=full_result_path,
+                num_rows=self.num_rows,
+                bound_lcs=self.bound_lcs,
+            )
+            attack_result = text_inclusion_attack.run_attack()
+            analysis_input_dict[result_path] = attack_result
+
+        return TextInclusionAnalysisInputBatch(input_batch=analysis_input_dict)
+
+    def run_attack(self) -> TextInclusionAnalysisInputBatch:
+        """
+        Pull results from mount directory and prepare input for text inclusion analysis.
+        """
+
+        analysis_input_batch = self.load_results_from_mnt()
+
+        return analysis_input_batch


### PR DESCRIPTION
Summary:
# Details

- Adds "`TextInclusionAttackBatch(BaseAttack)`", which takes a directory of LLM generations and prepares an TextInclusionAnalysisInputBatch, for use in text inclusion analysis
- The LLM generation directory is now searched recursively, instead of searching only for topline files

Differential Revision: D76137139


