### PR TITLE
Add `cap_eps` argument to `compute_metrics_at_error_threshold` which toggles whether to cap unreasonably large values of epsilon or not

### DIFF
--- a/analysis/analysis_node.py
+++ b/analysis/analysis_node.py
@@ -307,7 +307,10 @@ class AnalysisNode(BaseAnalysisNode):
                     )
                 ],
             ).compute_metrics_at_error_threshold(
-                self._delta, error_threshold=error_thresholds, verbose=False
+                self._delta,
+                error_threshold=error_thresholds,
+                cap_eps=self._cap_eps,
+                verbose=False,
             )
             for _ in tqdm(
                 range(self._num_bootstrap_resampling_times),

--- a/analysis/mia_results.py
+++ b/analysis/mia_results.py
@@ -235,6 +235,7 @@ class MIAResults:
         delta: float,
         # pyre-fixme[24]: Generic type `np.ndarray` expects 2 type parameters.
         error_threshold: np.ndarray,
+        cap_eps: bool = True,
         verbose: bool = False,
     ) -> tuple[np.float64, np.float64, list[np.float64], list[np.float64]]:
         """
@@ -258,10 +259,11 @@ class MIAResults:
             eps1 = np.log(1 - fnr - delta) - np.log(fpr)
             eps2 = np.log(tnr - delta) - np.log(fnr)
 
-        # filter out extreme values in eps1 and eps2
-        eps_ub = np.log(self._scores_train.shape[0])
-        eps1[eps1 > eps_ub] = 0.0
-        eps2[eps2 > eps_ub] = 0.0
+        if cap_eps:
+            # filter out extreme values in eps1 and eps2
+            eps_ub = np.log(self._scores_train.shape[0])
+            eps1[eps1 > eps_ub] = eps_ub
+            eps2[eps2 > eps_ub] = eps_ub
 
         eps_fpr_array = []
         eps_max_array = []

--- a/analysis/tests/test_analysis_node.py
+++ b/analysis/tests/test_analysis_node.py
@@ -61,7 +61,7 @@ class TestAnalysisNode(unittest.TestCase):
 
         self.score_analysis_node = ScoreAnalysisNode(analysis_input=self.analysis_input)
 
-        # Bengn setting where the test and train scores are sepearable
+        # Benign setting where the test and train scores are sepearable
         separable_df_train = pd.DataFrame({"score": np.array([0.1, 0.1]).reshape(-1)})
         separable_df_test = pd.DataFrame({"score": np.array([0, 0]).reshape(-1)})
         self.separable_base_analysis_input = BaseAnalysisInput(
@@ -141,9 +141,14 @@ class TestAnalysisNode(unittest.TestCase):
         )  # max eps over all TPR thresholds, should be log(2) ~ 0.693
         assert abs(eps_tpr_ub - np.log(2)) < 1e-6
 
+        eps_fpr_ub = max(
+            outputs["eps_fpr_ub"]
+        )  # max eps over all FPR thresholds, should be log(2) ~ 0.693
+        assert abs(eps_fpr_ub - np.log(2)) < 1e-6
+
     def test_turn_cap_eps_off(self) -> None:
         """
-        Tests capping of computed epsilons. Under cap_eps=False and a seprable setting with two users, the max eps should be inf.
+        Tests capping of computed epsilons. Under cap_eps=False and a separable setting with two users, the max eps should be inf.
         """
         analysis_node = AnalysisNode(
             self.separable_base_analysis_input,
@@ -156,6 +161,12 @@ class TestAnalysisNode(unittest.TestCase):
             outputs["eps_tpr_ub"]
         )  # max eps over all TPR thresholds, should be inf
         assert eps_tpr_ub == float("inf")
+
+        eps_fpr_ub = max(
+            outputs["eps_fpr_ub"]
+        )  # max eps over all FPR thresholds, should be inf
+        print(outputs["eps_tpr_ub"], outputs["eps_fpr_ub"])
+        assert eps_fpr_ub == float("inf")
 
     def test_num_bootstrap_resampling(self) -> None:
         """


### PR DESCRIPTION
Summary:
This diff introduces a new argument `cap_eps` to the `compute_metrics_at_error_threshold` method, which allows the user to toggle whether to cap unreasonably large values of epsilon or not. The default value of `cap_eps` is set to `True` to avoid impacting current prod readings. This makes it consistent with the method signature in `compute_eps_at_tpr_threshold` 

The changes include:

* Adding the `cap_eps` argument to the `compute_metrics_at_error_threshold` method in `mia_results.py`
* Passing the `cap_eps` argument from the `compute_metrics_at_error_threshold` method in `analysis_node.py` to the `compute_metrics_at_error_threshold` method in `mia_results.py`
* Updating the docstring in `mia_results.py` to reflect the new argument

Differential Revision: D77235199


