### PR TITLE
Add unittesting for CalibAttack on Ads tables

### DIFF
--- a/attacks/calib_attack.py
+++ b/attacks/calib_attack.py
@@ -2,7 +2,7 @@
 
 # pyre-strict
 
-from typing import List, Optional
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -45,7 +45,7 @@ class CalibAttack(BaseAttack):
         row_aggregation: AggregationType,
         should_calibrate_scores: bool,
         score_type: CalibScoreType,
-        merge_columns: list[str] | None = None,
+        merge_columns: List[str] | None = None,
     ) -> None:
         """
         args:
@@ -71,7 +71,7 @@ class CalibAttack(BaseAttack):
 
         self.score_type = score_type
 
-        self.merge_columns: list[str] = merge_columns or self.ADS_MERGE_COLUMNS
+        self.merge_columns: List[str] = merge_columns or self.ADS_MERGE_COLUMNS
 
         for column in self.merge_columns:
             for columns in [

--- a/attacks/tests/test_calib_attack.py
+++ b/attacks/tests/test_calib_attack.py
@@ -79,3 +79,28 @@ class TestCalibAttack(unittest.TestCase):
             [-1.26651961, 2.09382253, -1.10638714, 4.9806934, 5.47093052],
             decimal=7,
         )
+
+    def test_column_validation(self) -> None:
+        """Test that an IndexError is raised when a required column is missing."""
+        # Create a dataframe missing one of the required columns
+        df_missing_column = self.df_hold_out_train.drop(
+            columns=["impression_signature"]
+        )
+
+        # Verify that an IndexError is raised when trying to create a CalibAttack instance
+        with self.assertRaises(IndexError) as context:
+            CalibAttack(
+                df_hold_out_train=df_missing_column,
+                df_hold_out_test=self.df_hold_out_train,
+                df_hold_out_train_calib=self.df_hold_out_train,
+                df_hold_out_test_calib=self.df_hold_out_train,
+                row_aggregation=AggregationType.MAX,
+                should_calibrate_scores=False,
+                score_type=CalibScoreType.LOSS,
+            )
+
+        # Verify the error message
+        self.assertIn(
+            "column impression_signature not found in input dataframe(s)",
+            str(context.exception),
+        )


### PR DESCRIPTION
Summary: This diff adds unittesting for the CalibAttack class in the privacy_guard/attacks directory. The code changes add a new test case to verify that an IndexError is raised when a required column is missing from the dataframe

Differential Revision: D77389049


