### PR TITLE
Fixes inconsistent overrides in FDPAnalysis Node

### DIFF
--- a/analysis/fdp_analysis_node.py
+++ b/analysis/fdp_analysis_node.py
@@ -26,6 +26,9 @@ class FDPAnalysisNodeOutput(BaseAnalysisOutput):
 class FDPAnalysisNode(BaseAnalysisNode):
     def __init__(
         self,
+        m: int,
+        c: int,
+        c_cap: int,
         target_noise: float = 0.001,
         threshold: float = 0.05,
         k: int = 2,
@@ -34,6 +37,9 @@ class FDPAnalysisNode(BaseAnalysisNode):
         """
         Class to implement the FDP analysis in "Auditing f -Differential Privacy in One Run" (https://arxiv.org/abs/2410.22235)
 
+        :param m: Total number of canaries.
+        :param c: Number of correct guesses.
+        :param c_cap: Number of total guesses.
         :param target_noise: Initial noise level for candidate noises.
         :param threshold: Probability threshold value for auditing.
         :param k: alphabet size (k=2 for membership inference attacks).
@@ -50,6 +56,10 @@ class FDPAnalysisNode(BaseAnalysisNode):
         self.threshold = threshold
         self.delta = delta
         self.k = k
+
+        self.m = m
+        self.c = c
+        self.c_cap = c_cap
 
     @staticmethod
     def gaussianDP_blow_up_function(noise: float) -> Callable[[float], float]:
@@ -165,7 +175,7 @@ class FDPAnalysisNode(BaseAnalysisNode):
 
         return r[0] + h[0] <= c_cap / m
 
-    def run_analysis(
+    def run_analysis_with_parameters(
         self,
         m: int,
         c: int,
@@ -198,3 +208,13 @@ class FDPAnalysisNode(BaseAnalysisNode):
         empirical_eps = self.calculate_epsilon_gaussian(empirical_noise)
         output = FDPAnalysisNodeOutput(eps=empirical_eps)
         return output
+
+    def run_analysis(
+        self,
+    ) -> FDPAnalysisNodeOutput:
+        """
+        Runs analysis with default parameter arguments.
+
+        :return: Calculated epsilon value.
+        """
+        return self.run_analysis_with_parameters(m=self.m, c=self.c, c_cap=self.c_cap)

--- a/analysis/tests/test_fdp_analysis_node.py
+++ b/analysis/tests/test_fdp_analysis_node.py
@@ -18,12 +18,15 @@ class TestFDPAnalysisNode(unittest.TestCase):
     def setUp(self) -> None:
         """Set up test instances with different parameters."""
         # Create analysis nodes with different parameters
-        self.default_node = FDPAnalysisNode()
+        self.default_node = FDPAnalysisNode(m=1000, c=500, c_cap=800)
         self.custom_node = FDPAnalysisNode(
             target_noise=0.5,
             threshold=0.1,
             k=3,
             delta=1e-8,
+            m=1000,
+            c=500,
+            c_cap=800,
         )
         super().setUp()
 
@@ -203,13 +206,9 @@ class TestFDPAnalysisNode(unittest.TestCase):
 
     def test_run_analysis(self) -> None:
         """Test the run_analysis method."""
-        # Test parameters
-        m = 1000
-        c = 500
-        c_cap = 800
 
-        # Run the analysis
-        output = self.default_node.run_analysis(m, c, c_cap)
+        # Run the analysis (default args are m=1000, c=500, c_cap=800)
+        output = self.default_node.run_analysis()
 
         # Verify the output type
         self.assertIsInstance(output, FDPAnalysisNodeOutput)
@@ -224,12 +223,12 @@ class TestFDPAnalysisNode(unittest.TestCase):
         c = 1000
         c_cap = 1500
 
-        output = self.default_node.run_analysis(m, c, c_cap)
+        output = self.default_node.run_analysis_with_parameters(m=m, c=c, c_cap=c_cap)
         self.assertIsInstance(output, FDPAnalysisNodeOutput)
         self.assertGreater(output.eps, 0)
 
         # Test with custom node
-        output = self.custom_node.run_analysis(m, c, c_cap)
+        output = self.custom_node.run_analysis_with_parameters(m=m, c=c, c_cap=c_cap)
         self.assertIsInstance(output, FDPAnalysisNodeOutput)
         self.assertGreater(output.eps, 0)
 
@@ -242,7 +241,7 @@ class TestFDPAnalysisNode(unittest.TestCase):
 
         # Verify that an assertion error is raised
         with self.assertRaises(AssertionError):
-            self.default_node.run_analysis(m, c, c_cap)
+            self.default_node.run_analysis_with_parameters(m, c, c_cap)
 
         # Test parameters where c_cap > m
         m = 100
@@ -251,7 +250,7 @@ class TestFDPAnalysisNode(unittest.TestCase):
 
         # Verify that an assertion error is raised
         with self.assertRaises(AssertionError):
-            self.default_node.run_analysis(m, c, c_cap)
+            self.default_node.run_analysis_with_parameters(m, c, c_cap)
 
     def test_output_to_dict(self) -> None:
         """Test that the output can be converted to a dictionary."""
@@ -260,7 +259,7 @@ class TestFDPAnalysisNode(unittest.TestCase):
         c = 500
         c_cap = 800
 
-        output = self.default_node.run_analysis(m, c, c_cap)
+        output = self.default_node.run_analysis_with_parameters(m=m, c=c, c_cap=c_cap)
 
         # Convert to dictionary
         output_dict = output.to_dict()


### PR DESCRIPTION
Summary:
A recent diff (D77184572) started strictly enforcing strictly that method overrides are consistent with the base function.

This change updates fdp_analysis_node s.t its "run_analysis" method matches the definition in base_analysis_node. It also adds "run_analysis_with_parameters", to keep the functionality of specifying custom m, c, and c_cap for an existing node.

# Code Freeze Safety

Because FDPAnalysisNode is [not called elsewhere](https://fburl.com/code/yim44tcq) this fix is safe during the Ads code freeze.

Differential Revision: D77888656


