### PR TITLE
LIA integration

### DIFF
--- a/analysis/mia/aggregate_analysis_input.py
+++ b/analysis/mia/aggregate_analysis_input.py
@@ -20,6 +20,7 @@ class AggregationType(Enum):
     LOGSUMEXP = "logsumexp"
     GMEAN = "gmean"
     NONE = "none"
+    ABS_MAX = "abs_max"
 
 
 class AggregateAnalysisInput(BaseAnalysisInput):


### PR DESCRIPTION
Summary:
Add lightweight label inference attack to PrivacyGuard. 

Note: I also define a LIAAttackInput class which prepares the datasets before feeding them into the attack. The purpose of this is to speed up experimentation. Aggregation for LIA is expensive (since it uses .idxmax(). Therefore, we want to avoid re-doing the aggregation every time we change something in the attack or analysis.

Differential Revision: D77935914


