### PR TITLE
Allow specifying custom prompt and generation columns in TextInclusionAnalysis

### DIFF
--- a/analysis/extraction/text_inclusion_analysis_input.py
+++ b/analysis/extraction/text_inclusion_analysis_input.py
@@ -30,25 +30,37 @@ class TextInclusionAnalysisInput(BaseAnalysisInput):
         generation_df: dataframe containing prompt, target, and output_text columns
     """
 
-    REQUIRED_COLUMNS = {
-        "prompt",
-        "target",
-        "output_text",
-    }
-
     def __init__(
         self,
         generation_df: pd.DataFrame,
+        prompt_key: str = "prompt",
         target_key: str = "target",
+        generation_key: str = "output_text",
+        disable_exact_match: bool = False,
         disable_lcs: bool = False,
         disable_similarity: bool = False,
         lcs_bound_config: LCSBoundConfig | None = None,
     ) -> None:
-        self.target_key = target_key
+        columns = generation_df.columns.tolist()
+        assert (
+            prompt_key in columns
+        ), f"Prompt key '{prompt_key}' not found in dataframe columns {columns}"
+        assert (
+            target_key in columns
+        ), f"Target key '{target_key}' not found in dataframe columns {columns}"
+        assert (
+            generation_key in columns
+        ), f"Generation key '{generation_key}' not found in dataframe columns {columns}"
 
+        self.prompt_key = prompt_key
+        self.target_key = target_key
+        self.generation_key = generation_key
+
+        self.disable_exact_match = disable_exact_match
         self.disable_lcs = disable_lcs
         self.disable_similarity = disable_similarity
         self.lcs_bound_config = lcs_bound_config
+
         super().__init__(df_train_user=generation_df, df_test_user=pd.DataFrame())
 
     @property

--- a/analysis/scripts/text_inclusion_metrics.py
+++ b/analysis/scripts/text_inclusion_metrics.py
@@ -172,6 +172,7 @@ def run_analysis_on_json_data_impl(
         num_rows=None if num_rows <= 0 else num_rows,
         bound_lcs=bound_lcs,
     ).run_attack()
+    analysis_input.disable_exact_match = True
 
     analysis_node = TextInclusionAnalysisNode(analysis_input=analysis_input)
 

--- a/analysis/tests/test_text_inclusion.py
+++ b/analysis/tests/test_text_inclusion.py
@@ -58,6 +58,22 @@ class TestAnalysisInput(unittest.TestCase):
 
         super().setUp()
 
+    def test_column_not_in_dataframe(self) -> None:
+        with self.assertRaises(AssertionError):
+            _ = TextInclusionAnalysisInput(
+                generation_df=pd.DataFrame(self.data), prompt_key="NOT PRESENT"
+            )
+
+        with self.assertRaises(AssertionError):
+            _ = TextInclusionAnalysisInput(
+                generation_df=pd.DataFrame(self.data), target_key="NOT PRESENT"
+            )
+
+        with self.assertRaises(AssertionError):
+            _ = TextInclusionAnalysisInput(
+                generation_df=pd.DataFrame(self.data), generation_key="NOT PRESENT"
+            )
+
     def test_construct_text_inclusion_analysis_input(self) -> None:
         results = self.analysis_node.compute_outputs()
 
@@ -219,10 +235,6 @@ class TestAnalysisInput(unittest.TestCase):
                 "This is a test prompt",
                 "Exact match to prompt!",
             ],
-            "target": [
-                "Target text 1",
-                "Target text 2",
-            ],
             "targets": [
                 ["Target text 1", "Exact match to output_text!"],
                 ["Target text 2", "Exact match to prompt!"],
@@ -236,6 +248,7 @@ class TestAnalysisInput(unittest.TestCase):
         multi_analysis_input = TextInclusionAnalysisInput(
             generation_df=pd.DataFrame(multi_data),
             target_key="targets",
+            disable_exact_match=True,
             disable_similarity=True,
         )
         multi_analysis_node = TextInclusionAnalysisNode(
@@ -283,6 +296,9 @@ class TestAnalysisInput(unittest.TestCase):
         ].tolist()
 
         self.assertEqual(longest_common_substring_false_pos, expected_fp)
+
+        self.assertEqual(len(results["exact_match"]), 0)
+        self.assertEqual(len(results["inclusion_score"]), 0)
 
     def test_bounded_lcs_match(self) -> None:
         s1 = ("w" * 50) + ("t" * 160) + ("b" * 50) + ("t" * 155)

--- a/attacks/tests/test_text_inclusion_attack.py
+++ b/attacks/tests/test_text_inclusion_attack.py
@@ -114,16 +114,42 @@ class TestTextInclusionAttackBatch(TestCase):
 
         # Write some sample data to the files
         with open(file1_path, "w") as f1:
-            f1.write('{"id": 1, "text": "Sample text 1"}\n')
-            f1.write('{"id": 2, "text": "Sample text 2"}\n')
+            f1.write(
+                '{"id": 1, "text": "Sample text 1", "prompt": "PROMPT", "output_text": "output_text"}\n'
+            )
+            f1.write(
+                '{"id": 2, "text": "Sample text 2", "prompt": "PROMPT", "output_text": "output_text"}\n'
+            )
 
         with open(file2_path, "w") as f2:
-            f2.write('{"id": 3, "text": "Sample text 3"}\n')
-            f2.write('{"id": 4, "text": "Sample text 4"}\n')
+            f2.write(
+                '{"id": 3, "text": "Sample text 3", "prompt": "PROMPT", "output_text": "output_text"}\n'
+            )
+            f2.write(
+                '{"id": 4, "text": "Sample text 4", "prompt": "PROMPT", "output_text": "output_text"}\n'
+            )
 
         with open(file3_path, "w") as f2:
-            f2.write('{"id": 3, "text": "Sample text 5"}\n')
-            f2.write('{"id": 4, "text": "Sample text 6"}\n')
+            f2.write(
+                '{"id": 3, "text": "Sample text 5", "prompt": "PROMPT", "output_text": "output_text"}\n'
+            )
+            f2.write(
+                '{"id": 4, "text": "Sample text 6", "prompt": "PROMPT", "output_text": "output_text"}\n'
+            )
+
+        self.testReturnValue = TextInclusionAnalysisInput(
+            target_key="text",
+            generation_df=pd.DataFrame(
+                [
+                    {
+                        "id": 1,
+                        "text": "Sample text 1",
+                        "prompt": "PROMPT",
+                        "output_text": "output_text",
+                    }
+                ]
+            ),
+        )
 
         super().setUp()
 
@@ -136,7 +162,7 @@ class TestTextInclusionAttackBatch(TestCase):
         ) -> TextInclusionAnalysisInput:
             self.assertEqual(attack.bound_lcs, comparison_attack_batch.bound_lcs)
             self.assertEqual(attack.num_rows, comparison_attack_batch.num_rows)
-            return TextInclusionAnalysisInput(generation_df=pd.DataFrame())
+            return self.testReturnValue
 
         return mock_run_attack
 
@@ -184,9 +210,7 @@ class TestTextInclusionAttackBatch(TestCase):
             )
         )
 
-        mock_run_attack.return_value = TextInclusionAnalysisInput(
-            generation_df=pd.DataFrame()
-        )
+        mock_run_attack.return_value = self.testReturnValue
 
         with patch.object(TextInclusionAttack, "run_attack", mock_run_attack):
             result_batch = text_inclusion_attack_batch_filter.load_results_from_mnt()


### PR DESCRIPTION
Summary:
- Allows for specifying custom "prompt_key" and "generation_key" when using TextInclusionAnalysisNode. Before, these were hard coded to "prompt" and "output_text"
- Adds "disable_exact_match". This is included because exact match is not yet programmed to support multi target mode.
- Removes TextInclusionAnalysisInput::REQUIRED_COLUMNS, which was unused before

Reviewed By: knchadha

Differential Revision: D80711589


