### PR TITLE
Generation Attack +inference utils

### DIFF
--- a/attacks/extraction/generation_attack.py
+++ b/attacks/extraction/generation_attack.py
@@ -1,0 +1,160 @@
+# pyre-strict
+
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+import logging
+
+from typing import Any, Dict, Literal
+
+import pandas as pd
+
+from privacy_guard.analysis.extraction.text_inclusion_analysis_input import (
+    LCSBoundConfig,
+    TextInclusionAnalysisInput,
+)
+from privacy_guard.attacks.base_attack import BaseAttack
+
+from privacy_guard.attacks.extraction.utils.data_utils import (
+    load_data,
+    load_model_and_tokenizer,
+    save_results,
+)
+
+from privacy_guard.attacks.extraction.utils.model_inference import process_dataframe
+
+
+def setup_logger() -> logging.Logger:
+    """Set up the logger for the script."""
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+
+    # Remove any existing handlers to avoid duplicates
+    logger.handlers.clear()
+
+    logger.propagate = False
+
+    # Create console handler and set level
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+
+    # Create formatter
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
+    handler.setFormatter(formatter)
+
+    logger.addHandler(handler)
+
+    return logger
+
+
+logger: logging.Logger = setup_logger()
+
+
+TaskType = Literal["pretrain", "instruct"]
+FormatType = Literal["jsonl", "csv", "json"]
+
+
+class GenerationAttack(BaseAttack):
+    """
+    This attack, given a prompt set and a path to a LLM, executes generations and
+    prepares "TextInclusionAnalysisInput" for analysis.
+
+
+    Options:
+        --input_file: Path to the input file
+        --output_file: Optional to the output file. If none, outputs are not saved to file
+            and instead are saved only in the TextInclusionAnalysisInput.
+        --input_format: Format of the input file (jsonl, csv, json)
+        --output_format: Format of the output file (jsonl, csv, json)
+        --model_path: Path to the model
+        --device: Device to use (cuda, cpu)
+        --input_column: Name of the input column in the input file
+        --output_column: Name of the output column in the output dataframe
+        --batch_size: Batch size for processing
+        --max_new_tokens: Maximum number of new tokens to generate
+
+    """
+
+    def __init__(
+        self,
+        task: TaskType,
+        input_file: str,
+        output_file: str | None,
+        model_path: str,
+        input_format: FormatType = "jsonl",
+        output_format: FormatType | None = "jsonl",
+        device: str = "cuda",
+        input_column: str = "prompt",
+        output_column: str = "prediction",
+        batch_size: int = 4,
+        max_new_tokens: int = 512,
+        **generation_kwargs: Dict[str, Any],
+    ) -> None:
+        if output_file is None and output_format is not None:
+            logger.warning(
+                'Generation attack argument "output_format" is unused when output file is not specified'
+            )
+
+        self.task = task
+        self.input_file = input_file
+        self.output_file = output_file
+        self.input_format = input_format
+        self.output_format = output_format
+        self.model_path = model_path
+        self.device = device
+        self.input_column = input_column
+        self.output_column = output_column
+        self.batch_size = batch_size
+        self.max_new_tokens = max_new_tokens
+        self.generation_kwargs: Dict[str, Any] = generation_kwargs
+
+        # Load data
+        logger.info(f"Loading data from {input_file}")
+        self.input_df: pd.DataFrame = load_data(input_file, format=input_format)
+        logger.info(f"Loaded {len(self.input_df)} rows")
+
+        # Load model and tokenizer
+        logger.info(f"Loading model: {model_path}")
+        self.model, self.tokenizer = load_model_and_tokenizer(  # pyre-ignore
+            model_path, device=device
+        )
+        logger.info("Model loaded successfully. Generation attack is ready to run")
+
+    def run_attack(self) -> TextInclusionAnalysisInput:
+        # Process data
+        logger.info(f"Executing generation attack: {self.task}")
+        processed_df = process_dataframe(
+            df=self.input_df,
+            input_column=self.input_column,
+            output_column=self.output_column,
+            model=self.model,
+            tokenizer=self.tokenizer,
+            task=self.task,
+            batch_size=self.batch_size,
+            max_new_tokens=self.max_new_tokens,
+            **self.generation_kwargs,
+        )
+
+        logger.info("Processing complete")
+
+        # Save results
+        if self.output_file is not None:
+            output_path: str = self.output_file
+            output_format: str = str(self.output_format)
+            logger.info(f"Saving results to {output_path}")
+            save_results(df=processed_df, output_path=output_path, format=output_format)
+            logger.info("Results saved successfully")
+        else:
+            logger.info("No output file specified, not saving results to disk")
+
+        # TODO: Alternatively, call "TextInclusionAttack::run_attack()" directly
+        return TextInclusionAnalysisInput(
+            generation_df=processed_df,
+            disable_similarity=True,
+            prompt_key=self.input_column,
+            target_key="target",
+            generation_key=self.output_column,
+            lcs_bound_config=LCSBoundConfig(lcs_len_target=150, fp_len_target=50),
+        )
+        logger.info("Task completed successfully")

--- a/attacks/extraction/scripts/generation.py
+++ b/attacks/extraction/scripts/generation.py
@@ -1,0 +1,146 @@
+# pyre-strict
+
+#!/usr/bin/env python3
+"""
+Script for running various NLP tasks using the PrivacyGuard generation package.
+
+Usage:
+    buck run -c fbcode.enable_gpu_sections=true -c hpc_comms.use_nccl=2.18.3 privacy_guard/attacks/extraction/utils:generation_main --task [task_name] [options]
+
+Tasks:
+    - keyword_extraction: Extract keywords from text
+    - paraphrase: Paraphrase text
+    - summary: Summarize text
+
+Options:
+    --input_file: Path to the input file
+    --output_file: Path to the output file
+    --input_format: Format of the input file (jsonl, csv, json)
+    --output_format: Format of the output file (jsonl, csv, json)
+    --model_path: Path to the model
+    --device: Device to use (cuda, cpu)
+    --input_column: Name of the input column
+    --output_column: Name of the output column
+    --batch_size: Batch size for processing
+    --max_new_tokens: Maximum number of new tokens to generate
+"""
+
+import argparse
+import os
+
+from privacy_guard.attacks.extraction.generation_attack import GenerationAttack
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run NLP using PrivacyGuard GenerationAttack."
+    )
+
+    # Required arguments
+    parser.add_argument(
+        "--task",
+        type=str,
+        required=True,
+        choices=["pretrain", "instruct"],
+        help="The NLP task to perform",
+    )
+
+    # Optional arguments with defaults
+    parser.add_argument(
+        "--input_file",
+        type=str,
+        default="/tmp/input_data.jsonl",
+        help="Path to the input file",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        default="/tmp/output_{task}.jsonl",
+        help="Path to the output file. Use {task} as a placeholder for the task name.",
+    )
+    parser.add_argument(
+        "--input_format",
+        type=str,
+        default="jsonl",
+        choices=["jsonl", "csv", "json"],
+        help="Format of the input file",
+    )
+    parser.add_argument(
+        "--output_format",
+        type=str,
+        default="jsonl",
+        choices=["jsonl", "csv", "json"],
+        help="Format of the output file",
+    )
+    # Get current user for default model path
+    current_user = os.environ.get("USER", "default_user")
+
+    parser.add_argument(
+        "--model_path",
+        type=str,
+        default=f"/home/{current_user}/models/meta-llama/Meta-Llama-3.1-8B-Instruct",
+        help="Path to the model",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        choices=["cuda", "cpu"],
+        help="Device to use for processing",
+    )
+    parser.add_argument(
+        "--input_column",
+        type=str,
+        default="firstsecond_sentence",
+        help="Name of the input column in the data",
+    )
+    parser.add_argument(
+        "--output_column",
+        type=str,
+        default="{task}",
+        help="Name of the output column in the data. Use {task} as a default for the task name.",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=4,
+        help="Batch size for processing",
+    )
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=512,
+        help="Maximum number of new tokens to generate",
+    )
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Main function to run the generation."""
+
+    # Parse arguments
+    args = parse_args()
+
+    generation_attack = GenerationAttack(
+        task=args.task,
+        input_file=args.input_file,
+        output_file=args.output_file,
+        input_format=args.input_format,
+        output_format=args.output_format,
+        model_path=args.model_path,
+        device=args.device,
+        input_column=args.input_column,
+        output_column=args.output_column,
+        batch_size=args.batch_size,
+        max_new_tokens=args.max_new_tokens,
+    )
+
+    _ = generation_attack.run_attack()
+
+    return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/attacks/extraction/tests/test_generation_attack.py
+++ b/attacks/extraction/tests/test_generation_attack.py
@@ -1,0 +1,126 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+import os
+import tempfile
+import unittest
+
+from unittest.mock import ANY, MagicMock, patch
+
+import pandas as pd
+from privacy_guard.attacks.extraction.generation_attack import GenerationAttack
+
+
+class TestGenerationAttack(unittest.TestCase):
+    def setUp(self) -> None:
+        """Set up test data and mocks."""
+        self.generation_kwargs = {"temperature": 1, "top_k": 40}
+        self.input_file = tempfile.NamedTemporaryFile(suffix=".jsonl")
+        self.input_file_name = self.input_file.name
+
+        with open(self.input_file_name, "w") as f:
+            f.write('{"id": 1, "target": "Sample text 1", "prompt": "prompt 1"}\n')
+            f.write('{"id": 2, "target": "Sample text 2", "prompt": "prompt 1"}\n')
+
+        self.output_file = tempfile.NamedTemporaryFile(suffix=".jsonl")
+        self.output_file_name = self.output_file.name
+
+        # Mock model outputs
+        self.mock_model_outputs = pd.DataFrame(
+            [
+                {
+                    "id": 1,
+                    "target": "Sample text 1",
+                    "prompt": "prompt 1",
+                    "prediction": "pred 1",
+                },
+                {
+                    "id": 2,
+                    "target": "Sample text 2",
+                    "prompt": "prompt 1",
+                    "prediction": "pred 2",
+                },
+            ]
+        )
+
+        # Create simple mocks for model and tokenizer
+        # These are only used as parameters and not actually called in our tests
+        # since we're mocking process_with_llm
+        self.mock_model = MagicMock(device="cpu")
+        self.mock_tokenizer = MagicMock()
+
+    @patch("privacy_guard.attacks.extraction.generation_attack.process_dataframe")
+    @patch(
+        "privacy_guard.attacks.extraction.generation_attack.load_model_and_tokenizer"
+    )
+    def test_process_dataframe(
+        self,
+        mock_load_model_and_tokenizer: MagicMock,
+        mock_process_dataframe: MagicMock,
+    ) -> None:
+        mock_process_dataframe.return_value = self.mock_model_outputs
+        mock_load_model_and_tokenizer.side_effect
+        mock_load_model_and_tokenizer.return_value = (
+            self.mock_model,
+            self.mock_tokenizer,
+        )
+
+        generation_attack = GenerationAttack(
+            task="pretrain",
+            input_file=self.input_file_name,
+            output_file=None,
+            model_path="does/not/exist",
+            **self.generation_kwargs,  # pyre-ignore Incompatible parameter type [6]
+        )
+
+        _ = generation_attack.run_attack()
+
+        mock_process_dataframe.assert_called_once_with(
+            df=ANY,
+            input_column="prompt",
+            output_column="prediction",
+            model=self.mock_model,
+            tokenizer=self.mock_tokenizer,
+            task="pretrain",
+            batch_size=generation_attack.batch_size,
+            max_new_tokens=generation_attack.max_new_tokens,
+            **self.generation_kwargs,
+        )
+
+    @patch("privacy_guard.attacks.extraction.generation_attack.process_dataframe")
+    @patch(
+        "privacy_guard.attacks.extraction.generation_attack.load_model_and_tokenizer"
+    )
+    def test_process_dataframe_output_path(
+        self,
+        mock_load_model_and_tokenizer: MagicMock,
+        mock_process_dataframe: MagicMock,
+    ) -> None:
+        mock_process_dataframe.return_value = self.mock_model_outputs
+        mock_load_model_and_tokenizer.side_effect
+        mock_load_model_and_tokenizer.return_value = (
+            self.mock_model,
+            self.mock_tokenizer,
+        )
+
+        generation_attack = GenerationAttack(
+            task="instruct",
+            input_file=self.input_file_name,
+            output_file=self.output_file_name,
+            model_path="does/not/exist",
+        )
+
+        _ = generation_attack.run_attack()
+
+        mock_process_dataframe.assert_called_once_with(
+            df=ANY,
+            input_column="prompt",
+            output_column="prediction",
+            model=self.mock_model,
+            tokenizer=self.mock_tokenizer,
+            task="instruct",
+            batch_size=generation_attack.batch_size,
+            max_new_tokens=generation_attack.max_new_tokens,
+        )
+
+        self.assertTrue(os.path.getsize(self.output_file_name) > 0)

--- a/attacks/extraction/utils/data_utils.py
+++ b/attacks/extraction/utils/data_utils.py
@@ -1,0 +1,87 @@
+# pyre-strict
+
+"""
+Data Utilities Module
+
+This module provides functions for loading and saving data, as well as loading models and tokenizers.
+"""
+
+import json
+from typing import Optional, Tuple
+
+import pandas as pd
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    PreTrainedModel,
+    PreTrainedTokenizer,
+)
+
+
+def load_data(file_path: str, format: str = "jsonl") -> pd.DataFrame:
+    """
+    Load data from a file into a pandas DataFrame.
+
+    Args:
+        file_path: Path to the data file
+        format: Format of the data file ('jsonl', 'csv', 'json')
+
+    Returns:
+        DataFrame containing the loaded data
+    """
+    if format.lower() == "jsonl":
+        with open(file_path, "r") as file:
+            data = [json.loads(line) for line in file]
+        return pd.DataFrame(data)
+    elif format.lower() == "csv":
+        return pd.read_csv(file_path)
+    elif format.lower() == "json":
+        return pd.read_json(file_path)
+    else:
+        raise ValueError(f"Unsupported format: {format}")
+
+
+def save_results(df: pd.DataFrame, output_path: str, format: str = "jsonl") -> None:
+    """
+    Save results to a file.
+
+    Args:
+        df: DataFrame to save
+        output_path: Path to save the results to
+        format: Format to save the results in ('jsonl', 'csv', 'json')
+    """
+    if format.lower() == "jsonl":
+        df.to_json(output_path, orient="records", lines=True)
+    elif format.lower() == "csv":
+        df.to_csv(output_path, index=False)
+    elif format.lower() == "json":
+        df.to_json(output_path, orient="records")
+    else:
+        raise ValueError(f"Unsupported format: {format}")
+
+
+def load_model_and_tokenizer(
+    model_name_or_path: str, device: Optional[str] = None
+) -> Tuple[PreTrainedModel, PreTrainedTokenizer]:
+    """
+    Load a model and tokenizer.
+
+    Args:
+        model_name_or_path: Name or path of the model to load
+        device: Device to load the model on ('cuda', 'cpu', etc.)
+
+    Returns:
+        Tuple of (model, tokenizer)
+    """
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name_or_path)
+    model = AutoModelForCausalLM.from_pretrained(model_name_or_path).to(device)
+
+    # Ensure tokenizer has a pad token
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    return model, tokenizer

--- a/attacks/extraction/utils/model_inference.py
+++ b/attacks/extraction/utils/model_inference.py
@@ -1,0 +1,187 @@
+# pyre-strict
+
+"""
+Model Inference Module
+
+This module provides functions for processing texts through language models.
+"""
+
+from typing import Any, Dict, List, Literal, Optional
+
+import pandas as pd
+
+import torch
+
+from tqdm import tqdm
+from transformers import PreTrainedModel, PreTrainedTokenizer
+
+
+TaskType = Literal["pretrain", "instruct"]
+
+# NOTE: Custom task configs not yet implemented.
+TASK_CONFIG = {
+    "pretrain": {"prompt: {prompt}"},
+    "instruct": {"prompt": 'Complete the following passage: "{prompt}"'},
+}
+
+
+def process_batch_with_llm(
+    index: int,
+    batch: List[str],
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer,
+    task: TaskType,
+    batch_size: int = 8,
+    max_new_tokens: int = 512,
+    device: str = "cuda",
+    **generation_kwargs: Dict[str, Any],
+) -> List[str]:
+    # Ensure all items in the batch are strings
+    clean_batch = []
+    results = []
+    for item in batch:
+        if not isinstance(item, str):
+            print(f"Warning: Found non-string item in batch: {type(item)}")
+            try:
+                clean_batch.append(str(item))
+            except Exception as e:
+                print(f"Error converting item to string: {e}")
+                clean_batch.append("")
+        else:
+            clean_batch.append(item)
+
+    try:
+        inputs = tokenizer(
+            clean_batch, return_tensors="pt", padding=True, truncation=True
+        ).to(device)
+
+        with torch.no_grad():
+            # Handle both regular models and DDP-wrapped models
+            if hasattr(model, "module"):
+                outputs = model.module.generate(  # pyre-ignore Undefined attribute [16]: `transformers.utils.dummy_pt_objects.PreTrainedModel` has no attribute `module`.
+                    **inputs, max_new_tokens=max_new_tokens, **generation_kwargs
+                )
+            else:
+                outputs = model.generate(  # pyre-ignore Undefined attribute [16]: `transformers.utils.dummy_pt_objects.PreTrainedModel` has no attribute `generate`.
+                    **inputs, max_new_tokens=max_new_tokens, **generation_kwargs
+                )
+
+        batch_results: List[str] = tokenizer.batch_decode(
+            outputs, skip_special_tokens=True
+        )
+
+        results.extend(batch_results)
+    except Exception as e:
+        print(f"Error processing batch starting at index {index}: {e}")
+        # Add empty results for this batch
+        results.extend([""] * len(clean_batch))
+
+    return results
+
+
+def process_with_llm(
+    texts: List[str],
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer,
+    task: TaskType,
+    batch_size: int = 8,
+    max_new_tokens: int = 512,
+    device: str = "cuda",
+    **generation_kwargs: Dict[str, Any],
+) -> List[str]:
+    """
+    Process a list of texts through a language model.
+
+    Args:
+        texts: List of texts to process
+        model: The language model to use
+        tokenizer: The tokenizer for the model
+        task: Task type ('instruct, pretrain')
+        batch_size: Number of texts to process at once
+        max_new_tokens: Maximum number of new tokens to generate
+        device: Device to use for processing ('cuda', 'cpu', etc.)
+        generation_kwargs: Additional keyword arguments for model.generate()
+
+    Returns:
+        List of model outputs
+    """
+
+    # Process in batches for better performance
+    results = []
+    for i in tqdm(range(0, len(texts), batch_size), desc="Processing batches"):
+        batch = texts[i : i + batch_size]
+        new_results = process_batch_with_llm(
+            index=i,
+            batch=batch,
+            model=model,
+            tokenizer=tokenizer,
+            task=task,
+            batch_size=batch_size,
+            max_new_tokens=max_new_tokens,
+            device=device,
+            generation_kwargs=generation_kwargs,
+        )
+
+        results.extend(new_results)
+
+    return results
+
+
+def process_dataframe(
+    df: pd.DataFrame,
+    input_column: str,
+    output_column: str,
+    model: PreTrainedModel,
+    tokenizer: PreTrainedTokenizer,
+    task: TaskType = "pretrain",
+    device: Optional[str] = None,
+    batch_size: int = 8,
+    max_new_tokens: int = 512,
+    **generation_kwargs: Dict[str, Any],
+) -> pd.DataFrame:
+    """
+    Process a DataFrame through the entire pipeline: format, process with LLM, and postprocess.
+
+    Args:
+        df: DataFrame to process
+        input_column: Name of the column containing input text
+        output_column: Name of the column to store results
+        model: The language model to use
+        tokenizer: The tokenizer for the model
+        task: Task type ('instruct, pretrain')
+        batch_size: Number of texts to process at once
+        max_new_tokens: Maximum number of new tokens to generate
+        generation_kwargs: Additional keyword arguments for model.generate() ("temperature", "top_p")
+            Note that unused arguments will cause generation failures.
+
+    Returns:
+        DataFrame with processed results, with generations present under "output_column"
+    """
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    if hasattr(model, "device") and str(model.device) != device:  # pyre-ignore
+        model = model.to(device)  # pyre-ignore
+
+    if tokenizer.pad_token is None:
+        tokenizer.pad_token = tokenizer.eos_token
+
+    model_outputs = process_with_llm(
+        df[input_column].tolist(),
+        model,
+        tokenizer,
+        task=task,
+        batch_size=batch_size,
+        max_new_tokens=max_new_tokens,
+        device=device,
+        **generation_kwargs,
+    )
+    df["raw_model_output"] = model_outputs
+
+    # strip prompt from model output
+    generations = []
+    for input_text, raw_model_output in zip(df[input_column], model_outputs):
+        generations.append(raw_model_output[len(input_text) :])
+    df[output_column] = generations
+
+    return df

--- a/attacks/extraction/utils/tests/test_data_utils.py
+++ b/attacks/extraction/utils/tests/test_data_utils.py
@@ -1,0 +1,107 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+import os
+import tempfile
+import unittest
+from typing import Callable, Dict, List, Tuple
+
+import pandas as pd
+from privacy_guard.attacks.extraction.utils.data_utils import load_data, save_results
+
+
+class TestDataUtils(unittest.TestCase):
+    def setUp(self) -> None:
+        self.test_data: List[Dict[str, str]] = [
+            {"id": "1", "text": "This is test text 1", "label": "A"},
+            {"id": "2", "text": "This is test text 2", "label": "B"},
+            {"id": "3", "text": "This is test text 3", "label": "C"},
+        ]
+        self.df = pd.DataFrame(self.test_data)
+
+        self.temp_dir = tempfile.TemporaryDirectory()
+
+        self.formats: List[
+            Tuple[
+                str,
+                str,
+                Callable[[pd.DataFrame, str], None],
+                Callable[[str], pd.DataFrame],
+            ]
+        ] = [
+            (
+                "jsonl",
+                ".jsonl",
+                lambda df, path: df.to_json(path, orient="records", lines=True),
+                lambda path: pd.read_json(path, lines=True),
+            ),
+            (
+                "csv",
+                ".csv",
+                lambda df, path: df.to_csv(path, index=False),
+                lambda path: pd.read_csv(path),
+            ),
+            (
+                "json",
+                ".json",
+                lambda df, path: df.to_json(path, orient="records"),
+                lambda path: pd.read_json(path),
+            ),
+        ]
+
+        self.test_files = {}
+        for format_name, extension, write_func, _ in self.formats:
+            file_path = os.path.join(
+                self.temp_dir.name, f"test_{format_name}{extension}"
+            )
+            write_func(self.df, file_path)
+            self.test_files[format_name] = file_path
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def test_load_data(self) -> None:
+        for format_name, file_path in self.test_files.items():
+            with self.subTest(format=format_name):
+                df = load_data(file_path, format=format_name)
+
+                self.assertEqual(len(df), len(self.test_data))
+                self.assertEqual(list(df.columns), ["id", "text", "label"])
+
+                if format_name == "jsonl":
+                    self.assertEqual(
+                        df["text"].tolist(),
+                        [
+                            "This is test text 1",
+                            "This is test text 2",
+                            "This is test text 3",
+                        ],
+                    )
+                    self.assertEqual(df["label"].tolist(), ["A", "B", "C"])
+
+    def test_load_data_invalid_format(self) -> None:
+        with self.assertRaises(ValueError):
+            load_data(next(iter(self.test_files.values())), format="invalid")
+
+    def test_save_results(self) -> None:
+        for format_name, extension, _, read_func in self.formats:
+            with self.subTest(format=format_name):
+                output_path = os.path.join(
+                    self.temp_dir.name, f"output_{format_name}{extension}"
+                )
+
+                save_results(self.df, output_path, format=format_name)
+
+                self.assertTrue(os.path.exists(output_path))
+
+                loaded_df = read_func(output_path)
+                self.assertEqual(len(loaded_df), len(self.df))
+                self.assertEqual(list(loaded_df.columns), list(self.df.columns))
+
+    def test_save_results_invalid_format(self) -> None:
+        output_path = os.path.join(self.temp_dir.name, "output_invalid.txt")
+        with self.assertRaises(ValueError):
+            save_results(self.df, output_path, format="invalid")
+
+    # Note: We're not testing load_model_and_tokenizer here as it requires
+    # actual model files and would make the test slow and dependent on external resources.

--- a/attacks/extraction/utils/tests/test_model_inference.py
+++ b/attacks/extraction/utils/tests/test_model_inference.py
@@ -1,0 +1,107 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from privacy_guard.attacks.extraction.utils.model_inference import process_dataframe
+
+
+class TestAudienceExpansionPGEModelInference(unittest.TestCase):
+    def setUp(self) -> None:
+        """Set up test data and mocks."""
+        # Sample test data
+        self.test_texts = [
+            "This is test text 1. ",
+            "This is test text 2. ",
+            "This is test text 3. ",
+        ]
+        self.test_targets = [
+            "This is target text 1",
+            "This is target text 2",
+            "This is target text 3",
+        ]
+
+        # Sample DataFrame
+        self.df = pd.DataFrame(
+            {
+                "id": ["1", "2", "3"],
+                "text": self.test_texts,
+                "prompt": self.test_texts,
+                "target": self.test_targets,
+                "prompt_list": ["[text1]", "[text2]", "[text3]"],
+            }
+        )
+
+        # Mock model outputs
+        self.mock_model_outputs = [
+            "This is test text 1. This is target text 1",
+            "This is test text 2. This is target text 2",
+            "This is test text 3. This is target text 3",
+        ]
+
+        # Create simple mocks for model and tokenizer
+        # These are only used as parameters and not actually called in our tests
+        # since we're mocking process_with_llm
+        self.mock_model = MagicMock(device="cpu")
+        self.mock_tokenizer = MagicMock()
+
+    @patch("privacy_guard.attacks.extraction.utils.model_inference.process_with_llm")
+    def test_process_dataframe(self, mock_process_with_llm: MagicMock) -> None:
+        mock_process_with_llm.return_value = self.mock_model_outputs
+
+        result_df = process_dataframe(
+            df=self.df,
+            input_column="text",
+            output_column="output",
+            model=self.mock_model,
+            tokenizer=self.mock_tokenizer,
+            task="instruct",
+            batch_size=2,
+            max_new_tokens=100,
+            device="cpu",
+        )
+
+        self.assertEqual(len(result_df), len(self.df))
+        self.assertIn("raw_model_output", result_df.columns)
+        self.assertIn("output", result_df.columns)
+        self.assertEqual(
+            result_df["raw_model_output"].tolist(), self.mock_model_outputs
+        )
+        self.assertEqual(result_df["output"].tolist(), self.test_targets)
+
+        mock_process_with_llm.assert_called_once_with(
+            self.df["text"].tolist(),
+            self.mock_model,
+            self.mock_tokenizer,
+            task="instruct",
+            batch_size=2,
+            max_new_tokens=100,
+            device="cpu",
+        )
+
+    @patch("privacy_guard.attacks.extraction.utils.model_inference.process_with_llm")
+    def test_process_dataframe_with_prompt_list(
+        self, mock_process_with_llm: MagicMock
+    ) -> None:
+        mock_process_with_llm.return_value = self.mock_model_outputs
+
+        df_without_sentence = self.df.drop(columns=["prompt"])
+
+        result_df = process_dataframe(
+            df=df_without_sentence,
+            input_column="prompt_list",
+            output_column="output",
+            task="instruct",
+            model=self.mock_model,
+            tokenizer=self.mock_tokenizer,
+            batch_size=2,
+            max_new_tokens=100,
+        )
+
+        self.assertIn("prompt_list", result_df.columns)
+
+        self.assertEqual(len(result_df), len(df_without_sentence))
+        self.assertIn("raw_model_output", result_df.columns)
+        self.assertIn("output", result_df.columns)


### PR DESCRIPTION
Summary:
Generation interface for PrivacyGuard OSS, this allows for local eval runs. This will be used to provide an E2E OSS flow to
1. Create generations for a given model
2. Run PrivacyGuard Attacks+Analysis to compute memorization of the associated text.

# Next Step

- In script, pipe output to analysis
- Tutorial+Kernel

Differential Revision: D79269807
