### PR TITLE
Adding Probabilistic Memorization Analysis Node

### DIFF
--- a/analysis/probabilistic_memorization_analysis_input.py
+++ b/analysis/probabilistic_memorization_analysis_input.py
@@ -1,0 +1,49 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+import logging
+from typing import List, Optional
+
+import pandas as pd
+from privacy_guard.analysis.base_analysis_input import BaseAnalysisInput
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ProbabilisticMemorizationAnalysisInput(BaseAnalysisInput):
+    """
+    Takes in a single dataframe of generation data with prediction logprobs.
+
+    args:
+        generation_df: dataframe containing prediction_logprobs column (2D list)
+        prob_threshold: threshold for comparing model probabilities
+        n_values: optional list of n values for computing corresponding probabilities
+    """
+
+    REQUIRED_COLUMNS = {
+        "prediction_logprobs",
+    }
+
+    def __init__(
+        self,
+        generation_df: pd.DataFrame,
+        prob_threshold: float,
+        n_values: Optional[List[int]] = None,
+    ) -> None:
+        self.prob_threshold: float = prob_threshold
+        self.n_values: List[int] = n_values or []
+
+        # Validate required columns
+        missing_columns = self.REQUIRED_COLUMNS - set(generation_df.columns)
+        if missing_columns:
+            raise ValueError(f"Missing required columns: {missing_columns}")
+
+        super().__init__(df_train_user=generation_df, df_test_user=pd.DataFrame())
+
+    @property
+    def generation_df(self) -> pd.DataFrame:
+        """
+        Property accessor for generation_df
+        """
+        return self._df_train_user

--- a/analysis/probabilistic_memorization_analysis_node.py
+++ b/analysis/probabilistic_memorization_analysis_node.py
@@ -1,0 +1,114 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+import math
+from dataclasses import dataclass
+from typing import cast, Dict, List, Optional
+
+import pandas as pd
+from privacy_guard.analysis.base_analysis_node import BaseAnalysisNode
+from privacy_guard.analysis.base_analysis_output import BaseAnalysisOutput
+from privacy_guard.analysis.probabilistic_memorization_analysis_input import (
+    ProbabilisticMemorizationAnalysisInput,
+)
+
+from tqdm import tqdm
+
+tqdm.pandas()
+
+
+@dataclass
+class ProbabilisticMemorizationAnalysisNodeOutput(BaseAnalysisOutput):
+    num_samples: int
+    model_probability: pd.Series
+    above_probability_threshold: pd.Series
+    n_probabilities: Optional[pd.Series]
+    augmented_output_dataset: pd.DataFrame
+
+
+def _compute_model_probability(row: pd.Series) -> float:
+    """Compute model probability by summing up the prediction logprobs for each row. Currently only works for a single target (the most common use case).
+
+    Args:
+        row (pd.Series): A row of a DataFrame containing the "prediction_logprobs" column (each entry is a 2D list).
+
+    Returns:
+        float: The model probability for the target computed by summing up the logprobs.
+    """
+    prediction_logprobs = row["prediction_logprobs"]
+    # Sum up the logprobs for this row
+    if isinstance(prediction_logprobs, list) and len(prediction_logprobs) > 0:
+        if isinstance(prediction_logprobs[0], list):
+            if len(prediction_logprobs) > 1:
+                raise ValueError(
+                    "Invalid format for prediction_logprobs. Expected a 1D list of numbers or a nested list of a single list."
+                )
+            prediction_logprobs = prediction_logprobs[0]  # Unnest the list
+
+        # Check if it's a 1D list (all elements are numbers)
+        total_logprob = sum(prediction_logprobs)
+        model_prob = math.exp(total_logprob)
+        return model_prob
+    else:
+        return 0.0
+
+
+def _compute_n_probabilities_dict(
+    model_prob: float, n_values: List[int]
+) -> Dict[int, float]:
+    """Compute n-based probabilities for all n values using the formula p = 1 - (1 - model_prob)**n.
+
+    Args:
+        model_prob (float): The model probability.
+        n_values (List[int]): List of n values for calculations.
+
+    Returns:
+        Dict[int, float]: Dictionary mapping n to its corresponding probability.
+    """
+    return {n: 1.0 - ((1.0 - model_prob) ** n) for n in n_values}
+
+
+def _check_above_probability_threshold(model_prob: float, threshold: float) -> bool:
+    return model_prob > threshold
+
+
+class ProbabilisticMemorizationAnalysisNode(BaseAnalysisNode):
+    def __init__(self, analysis_input: ProbabilisticMemorizationAnalysisInput) -> None:
+        self.prob_threshold: float = analysis_input.prob_threshold
+        self.n_values: List[int] = analysis_input.n_values
+        self.generation_df: pd.DataFrame = analysis_input.generation_df
+
+        super().__init__(analysis_input=analysis_input)
+
+    def run_analysis(self) -> ProbabilisticMemorizationAnalysisNodeOutput:
+        analysis_input: ProbabilisticMemorizationAnalysisInput = cast(
+            ProbabilisticMemorizationAnalysisInput, self.analysis_input
+        )
+        generation_df = analysis_input.generation_df.copy()
+
+        # Compute model probabilities
+        model_probability = generation_df.progress_apply(
+            _compute_model_probability, axis=1
+        )
+        generation_df["model_probability"] = model_probability
+
+        # Check if above threshold
+        above_probability_threshold = model_probability.progress_apply(
+            lambda prob: _check_above_probability_threshold(prob, self.prob_threshold)
+        )
+        generation_df["above_probability_threshold"] = above_probability_threshold
+        # Compute n-based probabilities if n_values is provided
+        n_probabilities = None
+        if self.n_values:
+            n_probabilities = model_probability.progress_apply(
+                lambda prob: _compute_n_probabilities_dict(prob, self.n_values)
+            )
+            generation_df["n_probabilities"] = n_probabilities
+
+        return ProbabilisticMemorizationAnalysisNodeOutput(
+            num_samples=len(generation_df),
+            model_probability=model_probability,
+            above_probability_threshold=above_probability_threshold,
+            n_probabilities=n_probabilities,
+            augmented_output_dataset=generation_df,
+        )

--- a/analysis/scripts/probabilistic_memorization_analysis.py
+++ b/analysis/scripts/probabilistic_memorization_analysis.py
@@ -1,0 +1,132 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+# Example usage:
+# buck run //privacy_guard/analysis/scripts:probabilistic_memorization_analysis -- \
+#   --generation_path /path/to/generation_data.jsonl \
+#   --prob_threshold 0.5 \
+#   --output_path /path/to/output_results.jsonl \
+#   --n_values "10,100,1000"
+
+import argparse
+import logging
+from typing import List, Optional
+
+import pandas as pd
+from privacy_guard.analysis.probabilistic_memorization_analysis_input import (
+    ProbabilisticMemorizationAnalysisInput,
+)
+from privacy_guard.analysis.probabilistic_memorization_analysis_node import (
+    ProbabilisticMemorizationAnalysisNode,
+)
+
+from tqdm import tqdm
+
+tqdm.pandas()
+
+
+def dump_augmented_df(df: pd.DataFrame, jsonl_output_path: str) -> None:
+    jsonl_data = df.to_json(orient="records", lines=True)
+    with open(jsonl_output_path, "w") as f:
+        f.write(jsonl_data)
+
+
+def run_probabilistic_memorization_analysis(
+    generation_df_path: str,
+    prob_threshold: float,
+    output_path: str,
+    n_values: Optional[List[int]] = None,
+) -> pd.DataFrame:
+    """
+    Runs the probabilistic memorization analysis on the given dataframe and returns the results.
+
+    Args:
+        generation_df_path: Path to the generation dataframe JSONL file
+        prob_threshold: Probability threshold (p) for determining if a sample is memorized
+        output_path: Path to save the output JSONL file
+        n_values: Optional list of n values for computing corresponding probabilities,
+            where n is the number of attempts in which we compute the probability of outputting the target
+
+    Returns:
+        The augmented dataframe with analysis results
+    """
+    generation_df = pd.read_json(generation_df_path, lines=True)
+
+    analysis_input = ProbabilisticMemorizationAnalysisInput(
+        generation_df=generation_df,
+        prob_threshold=prob_threshold,
+        n_values=n_values,
+    )
+
+    analysis_node = ProbabilisticMemorizationAnalysisNode(analysis_input=analysis_input)
+    results = analysis_node.compute_outputs()
+
+    augmented_df = results["augmented_output_dataset"]
+
+    logging.info(f"Number of samples: {results['num_samples']}")
+    logging.info(
+        f"Samples above threshold: {results['above_probability_threshold'].sum()}"
+    )
+    logging.info(
+        f"Percentage above threshold: {results['above_probability_threshold'].mean() * 100:.2f}%"
+    )
+
+    if n_values:
+        logging.info(f"N-values analyzed: {n_values}")
+
+    dump_augmented_df(df=augmented_df, jsonl_output_path=output_path)
+    logging.info(f"Wrote analysis results to {output_path}")
+
+    return augmented_df
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+    )
+
+    parser = argparse.ArgumentParser(
+        description="Run probabilistic memorization analysis on generation data with prediction logprobs"
+    )
+    parser.add_argument(
+        "--generation_path",
+        help="Path to the generation dataframe JSONL file containing prediction_logprobs",
+        required=True,
+    )
+    parser.add_argument(
+        "--prob_threshold",
+        help="Threshold for comparing model probabilities",
+        default=0.01,
+        type=float,
+        required=True,
+    )
+    parser.add_argument(
+        "--output_path",
+        help="Path to save the output JSONL file",
+        required=True,
+    )
+    parser.add_argument(
+        "--n_values",
+        help="Comma-separated list of n values for computing corresponding probabilities (e.g., '10,100,1000')",
+        type=str,
+        default=None,
+    )
+
+    args = parser.parse_args()
+
+    # Parse n_values if provided
+    n_values = None
+    if args.n_values:
+        n_values = [int(n.strip()) for n in args.n_values.split(",")]
+
+    run_probabilistic_memorization_analysis(
+        generation_df_path=args.generation_path,
+        prob_threshold=args.prob_threshold,
+        output_path=args.output_path,
+        n_values=n_values,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/tests/test_probabilistic_memorization.py
+++ b/analysis/tests/test_probabilistic_memorization.py
@@ -1,0 +1,209 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+import math
+import unittest
+
+import pandas as pd
+
+from privacy_guard.analysis.probabilistic_memorization_analysis_input import (
+    ProbabilisticMemorizationAnalysisInput,
+)
+from privacy_guard.analysis.probabilistic_memorization_analysis_node import (
+    _check_above_probability_threshold,
+    _compute_model_probability,
+    _compute_n_probabilities_dict,
+    ProbabilisticMemorizationAnalysisNode,
+    ProbabilisticMemorizationAnalysisNodeOutput,
+)
+
+
+class TestProbabilisticMemorizationAnalysis(unittest.TestCase):
+    def setUp(self) -> None:
+        self.data = {
+            "prediction_logprobs": [
+                [
+                    [-0.1, -0.2, -0.05]
+                ],  # Single sublist: Sum: -0.35, exp(-0.35) ≈ 0.705 (above threshold)
+                [
+                    [-0.5, -0.3, -0.9]
+                ],  # Single sublist: Sum: -1.7, exp(-1.7) ≈ 0.183 (below threshold)
+                [[-0.2, -0.3]],  # Sum: -0.5, exp(-0.5) ≈ 0.607 (above threshold)
+                [[-1.2, -0.8]],  # Sum: -2.0, exp(-2.0) ≈ 0.135 (below threshold)
+                [],  # Empty, should return 0.0 (below threshold)
+            ]
+        }
+
+        self.prob_threshold = 0.5
+        self.n_values = [2, 5, 10]
+
+        self.analysis_input = ProbabilisticMemorizationAnalysisInput(
+            generation_df=pd.DataFrame(self.data),
+            prob_threshold=self.prob_threshold,
+            n_values=self.n_values,
+        )
+        self.analysis_node = ProbabilisticMemorizationAnalysisNode(
+            analysis_input=self.analysis_input
+        )
+
+        super().setUp()
+
+    def test_required_columns_validation(self) -> None:
+        """Test that missing required columns raise an error."""
+        invalid_data = {"invalid_column": [1, 2, 3]}
+        with self.assertRaises(ValueError):
+            ProbabilisticMemorizationAnalysisInput(
+                generation_df=pd.DataFrame(invalid_data),
+                prob_threshold=0.5,
+            )
+
+    def test_compute_model_probability(self) -> None:
+        # Test with single nested list (valid format)
+        row1 = pd.Series({"prediction_logprobs": [[-0.1, -0.2, -0.3]]})
+        expected1 = math.exp(-0.6)  # Sum is -0.6
+        self.assertAlmostEqual(_compute_model_probability(row1), expected1, places=5)
+
+        # Test with empty list
+        row2 = pd.Series({"prediction_logprobs": []})
+        self.assertEqual(_compute_model_probability(row2), 0.0)
+
+        # Test with single nested list containing one element
+        row3 = pd.Series({"prediction_logprobs": [[0.0]]})
+        self.assertEqual(_compute_model_probability(row3), 1.0)
+
+        # Test with 1D list (valid format)
+        row4 = pd.Series({"prediction_logprobs": [-0.5, -0.3, -0.2]})
+        expected4 = math.exp(-1.0)  # Sum is -1.0
+        self.assertAlmostEqual(_compute_model_probability(row4), expected4, places=5)
+
+    def test_compute_model_probability_error_cases(self) -> None:
+        # Test with multiple nested lists (should raise ValueError)
+        row_invalid = pd.Series({"prediction_logprobs": [[-0.1, -0.2], [-0.3, -0.4]]})
+        with self.assertRaises(ValueError) as context:
+            _compute_model_probability(row_invalid)
+        self.assertIn("Invalid format for prediction_logprobs", str(context.exception))
+
+    def test_compute_n_probabilities_dict(self) -> None:
+        model_prob = 0.8
+        n_values = [2, 5, 10]
+        result = _compute_n_probabilities_dict(model_prob, n_values)
+
+        # Expected calculations: p = 1 - (1 - model_prob)**n
+        expected = {
+            2: 1.0 - ((1.0 - 0.8) ** 2),  # 1 - 0.04 = 0.96
+            5: 1.0 - ((1.0 - 0.8) ** 5),  # 1 - 0.00032 ≈ 0.99968
+            10: 1.0 - ((1.0 - 0.8) ** 10),  # 1 - 1.024e-7 ≈ 0.9999999
+        }
+
+        self.assertEqual(set(result.keys()), set(expected.keys()))
+        for n in n_values:
+            self.assertAlmostEqual(result[n], expected[n], places=5)
+
+    def test_check_above_probability_threshold(self) -> None:
+        self.assertTrue(_check_above_probability_threshold(1.5, 1.0))
+        self.assertFalse(_check_above_probability_threshold(0.5, 1.0))
+        self.assertFalse(
+            _check_above_probability_threshold(1.0, 1.0)
+        )  # Equal is not above
+
+    def test_run_analysis_basic(self) -> None:
+        results = self.analysis_node.compute_outputs()
+
+        # Check that expected keys are present
+        self.assertIn("num_samples", results)
+        self.assertIn("model_probability", results)
+        self.assertIn("above_probability_threshold", results)
+        self.assertIn("n_probabilities", results)
+        self.assertIn("augmented_output_dataset", results)
+
+        # Check number of samples
+        self.assertEqual(results["num_samples"], 5)
+
+        # Check model probabilities are computed correctly
+        model_probs = results["model_probability"]
+        expected_model_probs = [
+            math.exp(-0.35),  # ≈ 0.705
+            math.exp(-1.7),  # ≈ 0.183
+            math.exp(-0.5),  # ≈ 0.607
+            math.exp(-2.0),  # ≈ 0.135
+            0.0,  # empty list
+        ]
+
+        for i, expected in enumerate(expected_model_probs):
+            self.assertAlmostEqual(model_probs.iloc[i], expected, places=3)
+
+        # Check threshold comparisons (threshold = 0.5)
+        above_probability_threshold = results["above_probability_threshold"]
+        expected_above_probability_threshold = [True, False, True, False, False]
+        self.assertEqual(
+            above_probability_threshold.tolist(), expected_above_probability_threshold
+        )
+
+        # Check n_probabilities structure
+        n_probabilities = results["n_probabilities"]
+        self.assertIsNotNone(n_probabilities)
+        for _i, n_prob_dict in enumerate(n_probabilities):
+            self.assertIsInstance(n_prob_dict, dict)
+            self.assertEqual(set(n_prob_dict.keys()), {2, 5, 10})
+            # Check that values are between 0 and 1
+            for _n, prob in n_prob_dict.items():
+                self.assertGreaterEqual(prob, 0.0)
+                self.assertLessEqual(prob, 1.0)
+
+    def test_output_types(self) -> None:
+        analysis_outputs = self.analysis_node.run_analysis()
+        self.assertIsInstance(
+            analysis_outputs, ProbabilisticMemorizationAnalysisNodeOutput
+        )
+
+        analysis_outputs_dict = self.analysis_node.compute_outputs()
+
+        self.assertIsInstance(analysis_outputs_dict, dict)
+        self.assertIsInstance(analysis_outputs_dict["num_samples"], int)
+        self.assertIsInstance(analysis_outputs_dict["model_probability"], pd.Series)
+        self.assertIsInstance(
+            analysis_outputs_dict["above_probability_threshold"], pd.Series
+        )
+        self.assertIsInstance(analysis_outputs_dict["n_probabilities"], pd.Series)
+        self.assertIsInstance(
+            analysis_outputs_dict["augmented_output_dataset"], pd.DataFrame
+        )
+
+    def test_no_n_values(self) -> None:
+        analysis_input = ProbabilisticMemorizationAnalysisInput(
+            generation_df=pd.DataFrame(self.data),
+            prob_threshold=self.prob_threshold,
+        )
+        analysis_node = ProbabilisticMemorizationAnalysisNode(
+            analysis_input=analysis_input
+        )
+
+        results = analysis_node.compute_outputs()
+
+        # Check that basic outputs are still present
+        self.assertIn("model_probability", results)
+        self.assertIn("above_probability_threshold", results)
+
+        # Check that n_probabilities is None when no n_values provided
+        self.assertIsNone(results["n_probabilities"])
+
+        # Check that n_probabilities column is not in augmented dataset
+        augmented_df = results["augmented_output_dataset"]
+        self.assertNotIn("n_probabilities", augmented_df.columns)
+
+    def test_augmented_output_dataset(self) -> None:
+        """Test that the augmented dataset contains all expected columns."""
+        results = self.analysis_node.compute_outputs()
+        augmented_df = results["augmented_output_dataset"]
+
+        # Check that original columns are preserved
+        self.assertIn("prediction_logprobs", augmented_df.columns)
+
+        # Check that computed columns are added
+        self.assertIn("model_probability", augmented_df.columns)
+        self.assertIn("above_probability_threshold", augmented_df.columns)
+        self.assertIn("n_probabilities", augmented_df.columns)
+
+        # Check that the number of rows is preserved
+        self.assertEqual(len(augmented_df), len(self.data["prediction_logprobs"]))


### PR DESCRIPTION
Summary:
1. Added ProbabilisticMemorization analysis node that computes model probabilities from prediction logprobs and performs threshold comparisons.
a. The node calculates n-based probabilities using the formula p = 1 - (1 - model_prob)**n, storing results as dictionaries in a single column for efficient data organization.
2. Added tests for the corresponding node.

Command to run analysis:

```bash
buck run //privacy_guard/analysis/scripts:probabilistic_memorization_analysis -- \
  --generation_path /path/to/generation_data.jsonl \
  --prob_threshold 0.5 \
  --output_path /path/to/output_results.jsonl \
  --n_values "10,100,1000"
```

Reviewed By: mgrange1998

Differential Revision: D80853682


