### PR TITLE
RMIA Class

### DIFF
--- a/attacks/rmia_attack.py
+++ b/attacks/rmia_attack.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env -S grimaldi --kernel python3
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# FILE_UID: a78b38b6-1640-4ecd-be8b-bc1e9247c278
+
+""":py"""
+
+# pyre-strict
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
+from privacy_guard.analysis.mia.aggregate_analysis_input import (
+    AggregateAnalysisInput,
+    AggregationType,
+)
+from privacy_guard.attacks.base_attack import BaseAttack
+from sklearn.metrics import auc, roc_curve
+
+
+class RmiaAttack(BaseAttack):
+    """
+    This is an implementation of Robust Membership Inference Attack (RMIA)
+    based on the paper: https://arxiv.org/abs/2312.03262.
+    Implementation incorporated into PrivacyGuard based on the official implementation from https://github.com/privacytrustlab/ml_privacy_meter/tree/master
+
+    The attack estimates population probability distributions using reference models and compares
+    the target model's predictions against estimated population averages to determine membership.
+
+    The attack leverages:
+        - Multiple reference models trained without target samples
+        - Population samples to establish baseline probability distributions
+        - Ratio-based scoring for membership inference
+    """
+
+    # Default column patterns for reference model data
+    REF_SCORE_PREFIX = "score_ref_"
+    REF_MEMBER_PREFIX = "member_ref_"
+
+    def __init__(
+        self,
+        df_train_merge: pd.DataFrame,
+        df_test_merge: pd.DataFrame,
+        df_population: pd.DataFrame,
+        row_aggregation: AggregationType,
+        num_reference_models: Optional[int] = None,
+        alpha_coefficient: float = 0.3,
+        enable_auto_tuning: bool = False,
+        user_id_key: str = "user_id",
+    ) -> None:
+        """
+        Initialize the RMIA attack.
+
+        Args:
+            df_train_merge: Training data with target and reference model scores
+            df_test_merge: Test data with target and reference model scores
+            df_population: Population data for probability distribution estimation
+            row_aggregation: User aggregation strategy specification
+            alpha_coefficient: Approximation coefficient for population probability estimation
+            num_reference_models: Number of reference models to use in attack (default: half of available models)
+            enable_auto_tuning: Enable automatic tuning of alpha_coefficient
+        """
+        self.df_train_merge: pd.DataFrame = df_train_merge.copy()
+        self.df_test_merge: pd.DataFrame = df_test_merge.copy()
+        self.df_population: pd.DataFrame = df_population.copy()
+        self.row_aggregation: AggregationType = row_aggregation
+        self.alpha_coefficient: float = alpha_coefficient
+
+        if num_reference_models is None:
+            # estimate number of reference models based on the number of columns in the dataframe
+            num_reference_models = max(df_population.shape[1] // 4, 1)
+        else:
+            # ensure that num_reference_models is not greater than the number of reference models available
+            num_reference_models = min(
+                num_reference_models, df_population.shape[1] // 2
+            )
+
+        self.num_reference_models: int = num_reference_models
+        self.enable_auto_tuning: bool = enable_auto_tuning
+        self.user_id_key: str = user_id_key
+
+        # Validate input data integrity
+        self._validate_input_data()
+
+    def _validate_input_data(self) -> None:
+        """
+        Validate that input dataframes contain required columns and data.
+
+        Raises:
+            ValueError: If required columns are missing or data is empty
+        """
+        for df_name, df in [
+            ("df_train_merge", self.df_train_merge),
+            ("df_test_merge", self.df_test_merge),
+            ("df_population", self.df_population),
+        ]:
+            if df.empty:
+                raise ValueError(f"{df_name} cannot be empty")
+
+            if "score_orig" not in df.columns:
+                raise ValueError(f"{df_name} must contain 'score_orig' column")
+
+        # Check for reference model columns
+        ref_score_cols = [
+            col
+            for col in self.df_train_merge.columns
+            if col.startswith(self.REF_SCORE_PREFIX)
+        ]
+        ref_member_cols = [
+            col
+            for col in self.df_train_merge.columns
+            if col.startswith(self.REF_MEMBER_PREFIX)
+        ]
+
+        if not ref_score_cols:
+            raise ValueError(
+                f"No reference score columns found (expected {self.REF_SCORE_PREFIX}*)"
+            )
+        if not ref_member_cols:
+            raise ValueError(
+                f"No reference membership columns found (expected {self.REF_MEMBER_PREFIX}*)"
+            )
+
+    @classmethod
+    def compute_ref_signal_averages(
+        cls,
+        ref_signals: np.ndarray,
+        ref_memberships: np.ndarray,
+        num_models: Optional[int] = None,
+        alpha: float = 0.3,
+    ) -> np.ndarray:
+        """
+        Compute average prediction probabilities from reference models excluding target samples.
+
+        Args:
+            ref_signals: Prediction scores from reference models
+            ref_memberships: Boolean membership matrix indicating training inclusion
+            num_models: Number of reference models to consider
+            alpha: Approximation coefficient for population probability
+
+        Returns:
+            Averaged prediction scores excluding membership samples
+        """
+        non_member_mask = ~ref_memberships
+        out_ref_signals = ref_signals * non_member_mask
+
+        if num_models is None:
+            num_models = ref_signals.shape[1] // 2
+
+        if num_models > 1:
+            # Select top non-zero signals for each sample
+            out_ref_signals = np.sort(out_ref_signals, axis=1)[:, -num_models:]
+        else:
+            # Apply single model approximation formula
+            if alpha != 0:
+                approximation = ((ref_signals + alpha - 1) / alpha) * ref_memberships
+                out_ref_signals += approximation
+            else:
+                # Default fallback approximation w/ alpha=0.3
+                fallback = ((ref_signals - 0.7) / 0.3) * ref_memberships
+                out_ref_signals += fallback
+
+        return out_ref_signals
+
+    def _auto_tune_alpha_coefficient(
+        self,
+        target_model_idx: int,
+        ref_scores: np.ndarray,
+        ref_memberships: np.ndarray,
+        population_ref_scores: np.ndarray,
+    ) -> float:
+        """Auto-tune alpha coefficient using cross-validation on reference models.
+        Args:
+            target_model_idx: Index of target model in reference scores
+            ref_scores: Reference model prediction scores
+            ref_memberships: Reference model membership matrix
+            population_ref_scores: Population reference model scores
+        Returns:
+            Tuned alpha coefficient
+        """
+        if ref_scores.shape[1] < 2:
+            print("Not enough reference models for auto-tuning")
+            return self.alpha_coefficient
+
+        # Select validation model
+        val_idx = target_model_idx
+        val_scores = ref_scores[:, val_idx]
+
+        # Set model for evaluation
+        eval_idx = [(val_idx + 1) % ref_scores.shape[1]]
+        eval_scores = ref_scores[:, eval_idx]
+        eval_memberships = ref_memberships[:, eval_idx]
+        eval_population_scores = population_ref_scores[:, eval_idx]
+
+        best_alpha, best_auc = 0.0, 0.0
+
+        for alpha in np.arange(0, 1.1, 0.1):
+            scores = self._compute_membership_scores(
+                val_scores,
+                eval_scores,
+                eval_memberships,
+                population_ref_scores[:, val_idx],
+                eval_population_scores,
+                alpha,
+                1,
+            )
+
+            fpr, tpr, _ = roc_curve(eval_memberships.astype(int), scores)
+            current_auc = auc(fpr, tpr)
+
+            if current_auc > best_auc:
+                best_auc = current_auc
+                best_alpha = alpha
+            print(f"Alpha ={alpha:.2f}, AUC={current_auc:.4f}")
+
+        print(f"Alpha tuning: best={best_alpha:.2f}, AUC={best_auc:.4f}")
+        return best_alpha
+
+    def _compute_membership_scores(
+        self,
+        target_scores: np.ndarray,
+        ref_scores: np.ndarray,
+        ref_memberships: np.ndarray,
+        population_target_scores: np.ndarray,
+        population_ref_scores: np.ndarray,
+        alpha: float,
+        num_models: int,
+    ) -> np.ndarray:
+        """
+        Execute core membership inference scoring algorithm.
+
+        Args:
+            target_scores: Target model prediction scores
+            ref_scores: Reference model prediction scores
+            ref_memberships: Reference model membership matrix
+            population_target_scores: Population target model scores
+            population_ref_scores: Population reference model scores
+            alpha: Population probability approximation coefficient
+            num_models: Number of reference models to use
+
+        Returns:
+            Membership inference scores (higher indicates greater membership likelihood)
+        """
+
+        # Compute reference signals for target dataset
+        target_ref_mean = self.compute_ref_signal_averages(
+            ref_scores, ref_memberships, num_models, alpha
+        )
+        target_mean_out = np.mean(target_ref_mean, axis=1)
+        target_population_estimate = (1 + alpha) / 2 * target_mean_out + (1 - alpha) / 2
+        target_probability_ratios = target_scores.ravel() / target_population_estimate
+
+        # Compute reference signals for population dataset
+        # Population samples are not used for training, so we set the membership to False
+        population_memberships = np.zeros_like(population_ref_scores).astype(bool)
+        population_ref_mean = self.compute_ref_signal_averages(
+            population_ref_scores, population_memberships, num_models, alpha
+        )
+        population_mean_out = np.mean(population_ref_mean, axis=1)
+        population_estimate = (1 + alpha) / 2 * population_mean_out + (1 - alpha) / 2
+        population_probability_ratios = (
+            population_target_scores.ravel() / population_estimate
+        )
+
+        # Calculate final membership scores
+        ratio_comparisons = (
+            target_probability_ratios[:, np.newaxis] / population_probability_ratios
+        )
+        membership_scores = np.average(ratio_comparisons > 1.0, axis=1)
+
+        return membership_scores
+
+    def _extract_model_data(
+        self, df: pd.DataFrame
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Extract and validate model prediction data from input dataframe.
+
+        Args:
+            df: Input dataframe containing model scores and membership data
+
+        Returns:
+            Tuple containing target scores, reference scores, and membership indicators
+
+        Raises:
+            ValueError: If required columns are missing from dataframe
+        """
+        # Validate and extract target model scores
+        if "score_orig" not in df.columns:
+            raise ValueError("Missing required 'score_orig' column in dataframe")
+        target_scores = df["score_orig"].values
+
+        # Extract reference model score columns
+        ref_score_columns = [
+            col for col in df.columns if col.startswith(self.REF_SCORE_PREFIX)
+        ]
+        if not ref_score_columns:
+            raise ValueError(
+                f"No reference score columns found (expected {self.REF_SCORE_PREFIX}*)"
+            )
+        ref_scores = df[ref_score_columns].values
+
+        # Extract reference model membership columns
+        ref_member_columns = [
+            col for col in df.columns if col.startswith(self.REF_MEMBER_PREFIX)
+        ]
+        if not ref_member_columns:
+            raise ValueError(
+                f"No membership columns found (expected {self.REF_MEMBER_PREFIX}*)"
+            )
+        ref_memberships = df[ref_member_columns].values.astype(bool)
+
+        return target_scores, ref_scores, ref_memberships
+
+    def run_attack(self) -> AggregateAnalysisInput:
+        """
+        Execute relative membership inference attack on input data.
+
+        Returns:
+            AggregateAnalysisInput: Output containing train and test data,
+            ready for consumption by different analyses
+        """
+        # Validate and extract model data from input dataframes
+        train_target_scores, train_ref_scores, train_ref_memberships = (
+            self._extract_model_data(self.df_train_merge)
+        )
+        test_target_scores, test_ref_scores, test_ref_memberships = (
+            self._extract_model_data(self.df_test_merge)
+        )
+        population_target_scores, population_ref_scores, _ = self._extract_model_data(
+            self.df_population
+        )
+
+        # Auto-tune alpha coefficient if requested
+        current_alpha = self.alpha_coefficient
+        if self.enable_auto_tuning:
+            # Use reference data for alpha tuning
+            # Combine training and test reference data for more robust tuning
+            combined_ref_scores = np.vstack([train_ref_scores, test_ref_scores])
+            combined_ref_memberships = np.vstack(
+                [train_ref_memberships, test_ref_memberships]
+            )
+
+            current_alpha = self._auto_tune_alpha_coefficient(
+                target_model_idx=0,  # Default target model index
+                ref_scores=combined_ref_scores,
+                ref_memberships=combined_ref_memberships,
+                population_ref_scores=population_ref_scores,
+            )
+            print(current_alpha)
+        # Compute membership scores for training data
+        train_membership_scores = self._compute_membership_scores(
+            target_scores=train_target_scores,
+            ref_scores=train_ref_scores,
+            ref_memberships=train_ref_memberships,
+            population_target_scores=population_target_scores,
+            population_ref_scores=population_ref_scores,
+            alpha=current_alpha,
+            num_models=self.num_reference_models,
+        )
+
+        # Compute membership scores for test data
+        test_membership_scores = self._compute_membership_scores(
+            target_scores=test_target_scores,
+            ref_scores=test_ref_scores,
+            ref_memberships=test_ref_memberships,
+            population_target_scores=population_target_scores,
+            population_ref_scores=population_ref_scores,
+            alpha=current_alpha,
+            num_models=self.num_reference_models,
+        )
+
+        # Create output dataframes with computed scores
+        self.df_train_merge["score"] = train_membership_scores
+        self.df_test_merge["score"] = test_membership_scores
+
+        # Return analysis input for downstream processing
+        analysis_input = AggregateAnalysisInput(
+            row_aggregation=self.row_aggregation,
+            df_train_merge=self.df_train_merge,
+            df_test_merge=self.df_test_merge,
+            user_id_key=self.user_id_key,
+        )
+
+        return analysis_input

--- a/attacks/tests/test_rmia_attack.py
+++ b/attacks/tests/test_rmia_attack.py
@@ -1,0 +1,515 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+
+import unittest
+
+import numpy as np
+import pandas as pd
+from numpy.testing import assert_array_almost_equal
+from privacy_guard.analysis.mia.aggregate_analysis_input import (
+    AggregateAnalysisInput,
+    AggregationType,
+)
+from privacy_guard.attacks.rmia_attack import RmiaAttack
+
+
+class TestRmiaAttack(unittest.TestCase):
+    def setUp(self) -> None:
+        # Create sample data for training
+        self.df_train_merge = pd.DataFrame(
+            {
+                "user_id": [
+                    123456,
+                    123456,
+                    789012,
+                    345678,
+                    901234,
+                ],
+                "score_orig": [0.8, 0.7, 0.6, 0.9, 0.5],
+                "score_ref_0": [0.4, 0.3, 0.5, 0.4, 0.6],
+                "score_ref_1": [0.5, 0.4, 0.4, 0.5, 0.3],
+                "score_ref_2": [0.3, 0.5, 0.6, 0.3, 0.4],
+                "member_ref_0": [True, False, True, False, True],
+                "member_ref_1": [False, True, False, True, False],
+                "member_ref_2": [True, True, False, False, True],
+            }
+        )
+
+        # Create sample data for testing (same structure but different values)
+        self.df_test_merge = pd.DataFrame(
+            {
+                "user_id": [
+                    567890,
+                    567890,
+                    112233,
+                    445566,
+                    778899,
+                ],
+                "score_orig": [0.2, 0.3, 0.4, 0.1, 0.5],
+                "score_ref_0": [0.6, 0.7, 0.5, 0.6, 0.4],
+                "score_ref_1": [0.5, 0.6, 0.6, 0.5, 0.7],
+                "score_ref_2": [0.7, 0.5, 0.4, 0.7, 0.6],
+                "member_ref_0": [False, True, False, True, False],
+                "member_ref_1": [True, False, True, False, True],
+                "member_ref_2": [False, False, True, True, False],
+            }
+        )
+
+        # Create population data for RMIA computation
+        self.df_population = pd.DataFrame(
+            {
+                "user_id": [111222, 333444, 555666],
+                "score_orig": [0.45, 0.55, 0.65],
+                "score_ref_0": [0.4, 0.5, 0.6],
+                "score_ref_1": [0.5, 0.4, 0.5],
+                "score_ref_2": [0.6, 0.6, 0.4],
+                "member_ref_0": [
+                    False,
+                    False,
+                    False,
+                ],  # Population data is always non-member
+                "member_ref_1": [False, False, False],
+                "member_ref_2": [False, False, False],
+            }
+        )
+
+        # Initialize RMIA attack instance
+        self.rmia_attack = RmiaAttack(
+            df_train_merge=self.df_train_merge,
+            df_test_merge=self.df_test_merge,
+            df_population=self.df_population,
+            row_aggregation=AggregationType.MAX,
+            alpha_coefficient=0.3,
+            num_reference_models=2,
+            enable_auto_tuning=False,
+        )
+
+        # Initialize RMIA attack with auto-tuning enabled
+        self.rmia_attack_auto_tune = RmiaAttack(
+            df_train_merge=self.df_train_merge,
+            df_test_merge=self.df_test_merge,
+            df_population=self.df_population,
+            row_aggregation=AggregationType.MAX,
+            alpha_coefficient=0.3,
+            num_reference_models=2,
+            enable_auto_tuning=True,
+        )
+
+        super().setUp()
+
+    def test_initialization_success(self) -> None:
+        """Test successful initialization of RmiaAttack"""
+        attack = RmiaAttack(
+            df_train_merge=self.df_train_merge,
+            df_test_merge=self.df_test_merge,
+            df_population=self.df_population,
+            row_aggregation=AggregationType.MAX,
+            num_reference_models=2,
+        )
+
+        self.assertEqual(attack.alpha_coefficient, 0.3)
+        self.assertEqual(attack.num_reference_models, 2)
+        self.assertFalse(attack.enable_auto_tuning)
+        self.assertEqual(attack.row_aggregation, AggregationType.MAX)
+
+    def test_initialization_empty_dataframe_error(self) -> None:
+        """Test that ValueError is raised when dataframes are empty"""
+        empty_df = pd.DataFrame()
+
+        with self.assertRaises(ValueError) as context:
+            RmiaAttack(
+                df_train_merge=empty_df,
+                df_test_merge=self.df_test_merge,
+                df_population=self.df_population,
+                row_aggregation=AggregationType.MAX,
+                num_reference_models=2,
+            )
+        self.assertIn("df_train_merge cannot be empty", str(context.exception))
+
+    def test_initialization_missing_score_orig_error(self) -> None:
+        """Test that ValueError is raised when score_orig column is missing"""
+        df_missing_score = self.df_train_merge.drop(columns=["score_orig"])
+
+        with self.assertRaises(ValueError) as context:
+            RmiaAttack(
+                df_train_merge=df_missing_score,
+                df_test_merge=self.df_test_merge,
+                df_population=self.df_population,
+                row_aggregation=AggregationType.MAX,
+                num_reference_models=2,
+            )
+        self.assertIn("must contain 'score_orig' column", str(context.exception))
+
+    def test_initialization_missing_ref_score_columns_error(self) -> None:
+        """Test that ValueError is raised when reference score columns are missing"""
+        df_missing_ref_scores = self.df_train_merge.drop(
+            columns=["score_ref_0", "score_ref_1", "score_ref_2"]
+        )
+
+        with self.assertRaises(ValueError) as context:
+            RmiaAttack(
+                df_train_merge=df_missing_ref_scores,
+                df_test_merge=self.df_test_merge,
+                df_population=self.df_population,
+                row_aggregation=AggregationType.MAX,
+                num_reference_models=2,
+            )
+        self.assertIn("No reference score columns found", str(context.exception))
+
+    def test_initialization_missing_ref_member_columns_error(self) -> None:
+        """Test that ValueError is raised when reference member columns are missing"""
+        df_missing_ref_members = self.df_train_merge.drop(
+            columns=["member_ref_0", "member_ref_1", "member_ref_2"]
+        )
+
+        with self.assertRaises(ValueError) as context:
+            RmiaAttack(
+                df_train_merge=df_missing_ref_members,
+                df_test_merge=self.df_test_merge,
+                df_population=self.df_population,
+                row_aggregation=AggregationType.MAX,
+                num_reference_models=2,
+            )
+        self.assertIn("No reference membership columns found", str(context.exception))
+
+    def test_extract_model_data_success(self) -> None:
+        """Test successful extraction of model data from dataframe"""
+        target_scores, ref_scores, ref_memberships = (
+            self.rmia_attack._extract_model_data(self.df_train_merge)
+        )
+
+        # Verify shapes
+        self.assertEqual(target_scores.shape, (5,))
+        self.assertEqual(ref_scores.shape, (5, 3))
+        self.assertEqual(ref_memberships.shape, (5, 3))
+
+        # Verify values
+        expected_target_scores = np.array([0.8, 0.7, 0.6, 0.9, 0.5])
+        assert_array_almost_equal(target_scores, expected_target_scores)
+
+        # Verify membership is boolean
+        self.assertTrue(ref_memberships.dtype == bool)
+
+    def test_extract_model_data_missing_score_orig_error(self) -> None:
+        """Test error when score_orig column is missing from dataframe"""
+        df_missing_score = self.df_train_merge.drop(columns=["score_orig"])
+
+        with self.assertRaises(ValueError) as context:
+            self.rmia_attack._extract_model_data(df_missing_score)
+        self.assertIn("Missing required 'score_orig' column", str(context.exception))
+
+    def test_compute_ref_signal_averages_multiple_models(self) -> None:
+        """Test computation of reference signal averages with multiple models"""
+        ref_signals = np.array(
+            [
+                [0.4, 0.5, 0.3],
+                [0.3, 0.4, 0.5],
+                [0.5, 0.4, 0.6],
+            ]
+        )
+        ref_memberships = np.array(
+            [
+                [True, False, True],
+                [False, True, True],
+                [True, False, False],
+            ]
+        )
+
+        result = RmiaAttack.compute_ref_signal_averages(
+            ref_signals=ref_signals,
+            ref_memberships=ref_memberships,
+            num_models=2,
+            alpha=0.3,
+        )
+
+        # Verify shape
+        self.assertEqual(result.shape, (3, 2))
+
+        # Verify non-zero exclusion logic works
+        self.assertTrue(np.all(result >= 0))
+
+    def test_compute_ref_signal_averages_single_model(self) -> None:
+        """Test computation of reference signal averages with single model"""
+        ref_signals = np.array(
+            [
+                [0.4],
+                [0.3],
+                [0.5],
+            ]
+        )
+        ref_memberships = np.array(
+            [
+                [True],
+                [False],
+                [True],
+            ]
+        )
+
+        result = RmiaAttack.compute_ref_signal_averages(
+            ref_signals=ref_signals,
+            ref_memberships=ref_memberships,
+            num_models=1,
+            alpha=0.3,
+        )
+
+        # Verify shape
+        self.assertEqual(result.shape, (3, 1))
+
+    def test_compute_ref_signal_averages_alpha_zero(self) -> None:
+        """Test computation with alpha=0 (fallback approximation)"""
+        ref_signals = np.array(
+            [
+                [0.4],
+                [0.8],
+            ]
+        )
+        ref_memberships = np.array(
+            [
+                [True],
+                [False],
+            ]
+        )
+
+        result = RmiaAttack.compute_ref_signal_averages(
+            ref_signals=ref_signals,
+            ref_memberships=ref_memberships,
+            num_models=1,
+            alpha=0.0,
+        )
+
+        # Verify fallback formula is applied
+        self.assertEqual(result.shape, (2, 1))
+
+    def test_compute_membership_scores(self) -> None:
+        """Test core membership score computation"""
+        # Create simple test data
+        target_scores = np.array([0.8, 0.2])
+        ref_scores = np.array([[0.4, 0.5], [0.6, 0.5]])
+        ref_memberships = np.array([[True, False], [False, True]])
+        population_target_scores = np.array([0.5, 0.6])
+        population_ref_scores = np.array([[0.4, 0.5], [0.5, 0.4]])
+
+        scores = self.rmia_attack._compute_membership_scores(
+            target_scores=target_scores,
+            ref_scores=ref_scores,
+            ref_memberships=ref_memberships,
+            population_target_scores=population_target_scores,
+            population_ref_scores=population_ref_scores,
+            alpha=0.3,
+            num_models=1,
+        )
+
+        # Verify output shape and type
+        self.assertEqual(scores.shape, (2,))
+        self.assertTrue(np.all(scores >= 0))
+        self.assertTrue(np.all(scores <= 1))
+
+    def test_auto_tune_alpha_coefficient(self) -> None:
+        """Test automatic tuning of alpha coefficient using reference models"""
+        # Create test data with multiple reference models (need at least 2 for auto-tuning)
+        ref_scores = np.array([[0.4, 0.5, 0.3], [0.6, 0.5, 0.4], [0.3, 0.4, 0.6]])
+        ref_memberships = np.array(
+            [[True, False, True], [False, True, False], [True, False, True]]
+        )
+        population_ref_scores = np.array([[0.4, 0.5, 0.3], [0.5, 0.4, 0.5]])
+
+        best_alpha = self.rmia_attack._auto_tune_alpha_coefficient(
+            ref_scores=ref_scores,
+            ref_memberships=ref_memberships,
+            population_ref_scores=population_ref_scores,
+            target_model_idx=0,
+        )
+
+        # Verify alpha is in valid range
+        self.assertGreaterEqual(best_alpha, 0.0)
+        self.assertLessEqual(best_alpha, 1.0)
+
+    def test_auto_tune_alpha_coefficient_insufficient_models(self) -> None:
+        """Test auto-tuning with insufficient reference models (< 2)"""
+        # Create test data with only 1 reference model
+        ref_scores = np.array([[0.4], [0.6], [0.3]])
+        ref_memberships = np.array([[True], [False], [True]])
+        population_ref_scores = np.array([[0.4], [0.5]])
+
+        # Should return the original alpha coefficient when insufficient models
+        best_alpha = self.rmia_attack._auto_tune_alpha_coefficient(
+            ref_scores=ref_scores,
+            ref_memberships=ref_memberships,
+            population_ref_scores=population_ref_scores,
+            target_model_idx=0,
+        )
+
+        # Should return the original alpha coefficient (0.3 from setUp)
+        self.assertEqual(best_alpha, self.rmia_attack.alpha_coefficient)
+
+    def test_run_attack_success(self) -> None:
+        """Test successful execution of RMIA attack"""
+        analysis_input = self.rmia_attack.run_attack()
+
+        # Verify return type
+        self.assertIsInstance(analysis_input, AggregateAnalysisInput)
+
+        # Verify output dataframes have scores
+        self.assertIn("score", analysis_input.df_train_merge.columns)
+        self.assertIn("score", analysis_input.df_test_merge.columns)
+
+        # Verify output lengths match input
+        self.assertEqual(len(analysis_input.df_train_merge), len(self.df_train_merge))
+        self.assertEqual(len(analysis_input.df_test_merge), len(self.df_test_merge))
+
+        # Verify scores are numeric and in reasonable range
+        train_scores = analysis_input.df_train_merge["score"].values
+        test_scores = analysis_input.df_test_merge["score"].values
+
+        self.assertTrue(np.all(train_scores >= 0))
+        self.assertTrue(np.all(train_scores <= 1))
+        self.assertTrue(np.all(test_scores >= 0))
+        self.assertTrue(np.all(test_scores <= 1))
+
+    def test_run_attack_with_auto_tuning(self) -> None:
+        """Test RMIA attack execution with auto-tuning enabled"""
+        analysis_input = self.rmia_attack_auto_tune.run_attack()
+
+        # Verify successful execution
+        self.assertIsInstance(analysis_input, AggregateAnalysisInput)
+
+        # Verify output has scores
+        self.assertIn("score", analysis_input.df_train_merge.columns)
+        self.assertIn("score", analysis_input.df_test_merge.columns)
+
+    def test_different_alpha_coefficients(self) -> None:
+        """Test attack with different alpha coefficient values"""
+        alpha_values = [0.0, 0.1, 0.5, 0.9, 1.0]
+
+        for alpha in alpha_values:
+            attack = RmiaAttack(
+                df_train_merge=self.df_train_merge,
+                df_test_merge=self.df_test_merge,
+                df_population=self.df_population,
+                row_aggregation=AggregationType.MAX,
+                alpha_coefficient=alpha,
+                num_reference_models=2,
+            )
+
+            analysis_input = attack.run_attack()
+
+            # Verify successful execution for all alpha values
+            self.assertIsInstance(analysis_input, AggregateAnalysisInput)
+            self.assertIn("score", analysis_input.df_train_merge.columns)
+
+    def test_different_num_reference_models(self) -> None:
+        """Test attack with different numbers of reference models"""
+        num_models_values = [None, 1, 2, 3, 10]
+
+        for num_models in num_models_values:
+            attack = RmiaAttack(
+                df_train_merge=self.df_train_merge,
+                df_test_merge=self.df_test_merge,
+                df_population=self.df_population,
+                row_aggregation=AggregationType.MAX,
+                num_reference_models=num_models,
+            )
+
+            analysis_input = attack.run_attack()
+
+            # Verify successful execution for all model counts
+            self.assertIsInstance(analysis_input, AggregateAnalysisInput)
+            self.assertIn("score", analysis_input.df_train_merge.columns)
+
+    def test_score_determinism(self) -> None:
+        """Test that running the same attack twice produces identical results"""
+        # First run
+        analysis_input_1 = self.rmia_attack.run_attack()
+        scores_1_train = analysis_input_1.df_train_merge["score"].values
+        scores_1_test = analysis_input_1.df_test_merge["score"].values
+
+        # Second run with same parameters
+        rmia_attack_2 = RmiaAttack(
+            df_train_merge=self.df_train_merge,
+            df_test_merge=self.df_test_merge,
+            df_population=self.df_population,
+            row_aggregation=AggregationType.MAX,
+            alpha_coefficient=0.3,
+            num_reference_models=2,
+            enable_auto_tuning=False,
+        )
+        analysis_input_2 = rmia_attack_2.run_attack()
+        scores_2_train = analysis_input_2.df_train_merge["score"].values
+        scores_2_test = analysis_input_2.df_test_merge["score"].values
+
+        # Verify identical results
+        assert_array_almost_equal(scores_1_train, scores_2_train, decimal=10)
+        assert_array_almost_equal(scores_1_test, scores_2_test, decimal=10)
+
+    def test_class_constants(self) -> None:
+        """Test that class constants are properly defined"""
+        self.assertEqual(RmiaAttack.REF_SCORE_PREFIX, "score_ref_")
+        self.assertEqual(RmiaAttack.REF_MEMBER_PREFIX, "member_ref_")
+
+    def test_aggregation_type_preservation(self) -> None:
+        """Test that aggregation type is preserved in output"""
+        analysis_input = self.rmia_attack.run_attack()
+        self.assertEqual(analysis_input.row_aggregation, AggregationType.MAX)
+
+    def test_compute_ref_signal_averages_num_models_none(self) -> None:
+        """Test compute_ref_signal_averages when num_models is None"""
+        ref_signals = np.array(
+            [
+                [0.4, 0.5, 0.3],
+                [0.3, 0.4, 0.5],
+                [0.5, 0.4, 0.6],
+            ]
+        )
+        ref_memberships = np.array(
+            [
+                [True, False, True],
+                [False, True, True],
+                [True, False, False],
+            ]
+        )
+
+        # Call with num_models=None
+        result = RmiaAttack.compute_ref_signal_averages(
+            ref_signals=ref_signals,
+            ref_memberships=ref_memberships,
+            num_models=None,
+            alpha=0.3,
+        )
+
+        # Verify that num_models was set to ref_signals.shape[1] (which is 3)
+        self.assertEqual(result.shape, (3, 3))
+
+    def test_extract_model_data_missing_ref_score_columns_error(self) -> None:
+        """Test error when reference score columns are missing"""
+        # Create dataframe without reference score columns
+        df_no_ref_scores = pd.DataFrame(
+            {
+                "score_orig": [0.8, 0.7, 0.6],
+                "member_ref_0": [True, False, True],
+                "member_ref_1": [False, True, False],
+            }
+        )
+
+        with self.assertRaises(ValueError) as context:
+            self.rmia_attack._extract_model_data(df_no_ref_scores)
+
+        self.assertIn("No reference score columns found", str(context.exception))
+        self.assertIn("score_ref_", str(context.exception))
+
+    def test_extract_model_data_missing_ref_member_columns_error(self) -> None:
+        """Test error when reference member columns are missing"""
+        # Create dataframe without reference member columns
+        df_no_ref_members = pd.DataFrame(
+            {
+                "score_orig": [0.8, 0.7, 0.6],
+                "score_ref_0": [0.4, 0.3, 0.5],
+                "score_ref_1": [0.5, 0.4, 0.4],
+            }
+        )
+
+        with self.assertRaises(ValueError) as context:
+            self.rmia_attack._extract_model_data(df_no_ref_members)
+
+        self.assertIn("No membership columns found", str(context.exception))
+        self.assertIn("member_ref_", str(context.exception))


### PR DESCRIPTION
Summary:
This diff introduces a new class, `RmiaAttack`, which implements the Robust Membership Inference Attack (RMIA). The RMIA is an attack that estimates population probability distributions using reference model predictions.
In the next diff, we will push a tutorial on how to use this class for CIFAR10
**Changes**
-----------

### BUCK File

The diff adds a new `python_library` target, `rmia_attack`, which includes the `rmia_attack.py` file and its dependencies. It also adds a new `python_unittest` target, `test_rmia_attack`, which includes the `tests/test_rmia_attack.py` file and its dependencies.

### rmia_attack.py

This new file defines the `RmiaAttack` class, which inherits from the `BaseAttack` class.

### tests/test_rmia_attack.py

This new file defines a test class, `TestRmiaAttack`, which includes several test methods for the `RmiaAttack` class.

Reviewed By: mgrange1998

Differential Revision: D80200703


