### PR TITLE
Remove "empirical_dp" reference in tutorials, point to privacy guard kernel

### DIFF
--- a/tutorials/lira_attack_cifar10_tutorial.py
+++ b/tutorials/lira_attack_cifar10_tutorial.py
@@ -1,5 +1,5 @@
 # pyre-strict
-#!/usr/bin/env -S grimaldi --kernel empirical_dp
+#!/usr/bin/env -S grimaldi --kernel bento_kernel_privacy_guard
 # FILE_UID: 3eb7d962-95ba-4ce9-8fa7-c288845d3cbf
 # NOTEBOOK_NUMBER: N7714854 (1978195306257478)
 

--- a/tutorials/loss_attack_tutorial.py
+++ b/tutorials/loss_attack_tutorial.py
@@ -1,5 +1,5 @@
 # pyre-ignore-all-errors
-#!/usr/bin/env -S grimaldi --kernel bento_kernel_empirical_dp
+#!/usr/bin/env -S grimaldi --kernel bento_kernel_privacy_guard
 # FILE_UID: 65090375-6bbb-4bbb-b05f-3e0dd15dbbff
 # NOTEBOOK_NUMBER: N7208437 (9923413411059195)
 


### PR DESCRIPTION
Summary:
This updates the kernel of OSS tutorials to reference the privacy guard kernel, as references to "empirical_dp" will remain internal. 

The empirical_dp kernel will continue to be supported, as both it and the privacy guard kernel depend on the same PrivacyGuard library BUCK target.

Differential Revision: D81245330


