### PR TITLE
Remove empirical_dp in RMIA tutorial and use privacyguard kernel

### DIFF
--- a/tutorials/rmia_attack_cifar10_tutorial.py
+++ b/tutorials/rmia_attack_cifar10_tutorial.py
@@ -1,5 +1,5 @@
 # pyre-strict
-#!/usr/bin/env -S grimaldi --kernel bento_kernel_empirical_dp
+#!/usr/bin/env -S grimaldi --kernel bento_kernel_privacy_guard
 # FILE_UID: 4fb8e073-a6cb-4de0-9ga8-d399956e4dcg
 # NOTEBOOK_NUMBER: N7946452 (1473839753932919)
 


### PR DESCRIPTION
Summary: This updates the kernel of OSS RMIA tutorial to reference the privacy guard kernel, as references to "empirical_dp" will remain internal.

Differential Revision: D81593679


