### PR TITLE
Add probabilistic memorization analysis from logits stubs

### DIFF
--- a/analysis/extraction/probabilistic_memorization_analysis_from_logits_input.py
+++ b/analysis/extraction/probabilistic_memorization_analysis_from_logits_input.py
@@ -1,0 +1,55 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+import logging
+from typing import List, Optional
+
+import pandas as pd
+from privacy_guard.analysis.base_analysis_input import BaseAnalysisInput
+
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class ProbabilisticMemorizationAnalysisFromLogitsInput(BaseAnalysisInput):
+    """
+    Takes in a single dataframe of generation data with prediction logits.
+
+    args:
+        generation_df: dataframe containing prediction_logits column
+        temp: temperature parameter for sampling
+        topK: topK parameter for sampling
+        prob_threshold: threshold for comparing model probabilities
+        n_values: optional list of n values for computing corresponding probabilities of model outputting the target in n attempts. Refer to https://arxiv.org/abs/2410.19482 for details.
+    """
+
+    REQUIRED_COLUMNS = {
+        "prediction_logits",
+    }
+
+    def __init__(
+        self,
+        generation_df: pd.DataFrame,
+        temp: float,
+        topK: int,
+        prob_threshold: float,
+        n_values: Optional[List[int]] = None,
+    ) -> None:
+        self.temp: float = temp
+        self.topK: int = topK
+        self.prob_threshold: float = prob_threshold
+        self.n_values: List[int] = n_values or []
+
+        # Validate required columns
+        missing_columns = self.REQUIRED_COLUMNS - set(generation_df.columns)
+        if missing_columns:
+            raise ValueError(f"Missing required columns: {missing_columns}")
+
+        super().__init__(df_train_user=generation_df, df_test_user=pd.DataFrame())
+
+    @property
+    def generation_df(self) -> pd.DataFrame:
+        """
+        Property accessor for generation_df
+        """
+        return self._df_train_user

--- a/analysis/extraction/probabilistic_memorization_analysis_from_logits_node.py
+++ b/analysis/extraction/probabilistic_memorization_analysis_from_logits_node.py
@@ -1,0 +1,103 @@
+# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+# pyre-strict
+from dataclasses import dataclass
+from typing import Any, cast, List, Optional
+
+import pandas as pd
+from privacy_guard.analysis.base_analysis_node import BaseAnalysisNode
+from privacy_guard.analysis.base_analysis_output import BaseAnalysisOutput
+from privacy_guard.analysis.extraction.probabilistic_memorization_analysis_from_logits_input import (
+    ProbabilisticMemorizationAnalysisFromLogitsInput,
+)
+
+from tqdm import tqdm
+
+tqdm.pandas()
+
+
+@dataclass
+class ProbabilisticMemorizationAnalysisFromLogitsNodeOutput(BaseAnalysisOutput):
+    num_samples: int
+    model_probability: pd.Series
+    above_probability_threshold: pd.Series
+    n_probabilities: Optional[pd.Series]
+    augmented_output_dataset: pd.DataFrame
+
+
+def _compute_model_probability_from_logits(
+    row: pd.Series, temp: float, topK: int
+) -> float:
+    """Compute model probability from prediction logits using temperature and topK sampling.
+
+    TODO: Implement this function to:
+    1. Convert logits to probabilities using temperature scaling
+    2. Apply topK sampling
+    3. Compute the model probability for the target
+
+    Args:
+        row (pd.Series): A row of a DataFrame containing the "prediction_logits" column.
+        temp (float): Temperature parameter for sampling.
+        topK (int): TopK parameter for sampling.
+
+    Returns:
+        float: The model probability for the target.
+    """
+    # TODO: Implement this function
+    return 0.0
+
+
+class ProbabilisticMemorizationAnalysisFromLogitsNode(BaseAnalysisNode):
+    def __init__(
+        self, analysis_input: ProbabilisticMemorizationAnalysisFromLogitsInput
+    ) -> None:
+        self.temp: float = analysis_input.temp
+        self.topK: int = analysis_input.topK
+        self.prob_threshold: float = analysis_input.prob_threshold
+        self.n_values: List[int] = analysis_input.n_values
+        self.generation_df: pd.DataFrame = analysis_input.generation_df
+
+        super().__init__(analysis_input=analysis_input)
+
+    def apply_temp_and_topK(self, logits: Any, temp: float, topK: int) -> Any:
+        """Apply temperature scaling and topK sampling to logits.
+
+        TODO: Implement this function to:
+        1. Apply temperature scaling to the logits
+        2. Apply topK sampling to select the top K logits
+        3. Return the processed logits/probabilities
+
+        Args:
+            logits (Any): The input logits to process.
+            temp (float): Temperature parameter for scaling.
+            topK (int): Number of top logits to keep.
+
+        Returns:
+            Any: The processed logits/probabilities after temperature and topK application.
+        """
+        # TODO: Implement this function
+        return None
+
+    def run_analysis(self) -> ProbabilisticMemorizationAnalysisFromLogitsNodeOutput:
+        """Run the probabilistic memorization analysis from logits.
+
+        TODO: Implement this function to:
+        1. Compute model probabilities from logits using temperature and topK
+        2. Check if probabilities are above threshold
+        3. Compute n-based probabilities if n_values is provided
+        4. Return the analysis output
+        """
+        # TODO: Implement the full analysis logic
+        analysis_input: ProbabilisticMemorizationAnalysisFromLogitsInput = cast(
+            ProbabilisticMemorizationAnalysisFromLogitsInput, self.analysis_input
+        )
+        generation_df = analysis_input.generation_df.copy()
+
+        # Placeholder return - to be implemented
+        return ProbabilisticMemorizationAnalysisFromLogitsNodeOutput(
+            num_samples=len(generation_df),
+            model_probability=pd.Series(dtype=float),
+            above_probability_threshold=pd.Series(dtype=bool),
+            n_probabilities=None,
+            augmented_output_dataset=generation_df,
+        )


### PR DESCRIPTION
Summary: Created stub implementation for `probabilistic_memorization_analysis_from_logits` input and node classes, similar to existing probabilistic memorization analysis but designed to work with prediction logits instead of logprobs. Added temperature and topK sampling parameters, updated BUCK dependencies, and included `apply_temp_and_topK()` helper function. All logic left unimplemented with TODO comments for future development.

Differential Revision: D81372077


