### PR TITLE
Support for custom LCS TextInclusionAnalysisNode

### DIFF
--- a/analysis/extraction/text_inclusion_analysis_input.py
+++ b/analysis/extraction/text_inclusion_analysis_input.py
@@ -70,6 +70,14 @@ class TextInclusionAnalysisInput(BaseAnalysisInput):
         """
         return self._df_train_user
 
+    def update_lcs_bound_config(self, lcs_len_target: int, fp_len_target: int) -> None:
+        """
+        Update the lcs bound config
+        """
+        self.lcs_bound_config = LCSBoundConfig(
+            lcs_len_target=lcs_len_target, fp_len_target=fp_len_target
+        )
+
 
 class TextInclusionAnalysisInputBatch(BaseAnalysisInput):
     def __init__(self, input_batch: Dict[str, TextInclusionAnalysisInput]) -> None:

--- a/attacks/text_inclusion_attack.py
+++ b/attacks/text_inclusion_attack.py
@@ -109,7 +109,7 @@ class TextInclusionAttack(BaseAttack):
         analysis_input = TextInclusionAnalysisInput(
             generation_df=data,
             disable_similarity=True,
-            target_key="targets",
+            target_key="target",
             lcs_bound_config=lcs_bound_config,
         )
         return analysis_input


### PR DESCRIPTION
Summary:
This change adds support for a configurable LCS and FP bound threshold, instead of hard-coding it to 150 characters.

This is done by allowing the LCSBoundConfig to be updated once the TextInclusionAnalysisInput is created

Differential Revision: D81323685


