### PR TITLE
pyproject.toml, LICENSE, README files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Contributing
+
+See the CONTRIBUTING file for how to help out.
+When contributing to PrivacyGuard, we recommend cloning the repository and installing all optional dependencies:
+
+git clone https://github.com/facebookresearch/PrivacyGuard.git --depth 1
+cd PrivacyGuard
+pip install -e .[tutorial]
+
+The above example limits the cloned directory size via the --depth argument to git clone. If you require the entire commit history you may remove this argument.
+
+
+# License
+
+PrivacyGuard is licensed under the MIT license.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,83 @@
+[build-system]
+requires = ["setuptools>=34.4", "wheel", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "privacy-guard"
+description = "PrivacyGuard"
+authors = [{name = "Meta Platforms, Inc."}]
+license = "MIT"
+license-files = ["LICENSE"]
+readme = "README.md"
+requires-python = ">=3.10"
+keywords = ["PrivacyGuard", "Privacy", "Privacy Attack", "Privacy Analysis"]
+classifiers = [
+    "Private :: Do Not Upload", # Required to prevent PyPI uploads
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Programming Language :: Python :: 3",
+]
+dynamic = ["version"]
+
+dependencies = [ # need to double check which of these are required.
+    "jinja2",  # also a Plotly dep
+    "pandas",
+    "scipy",
+    "scikit-learn",
+    "ipywidgets",
+    # Needed for compatibility with ipywidgets >= 8.0.0
+    "plotly>=5.12.0",
+    "pyre-extensions",
+    "sympy",
+    "markdown",
+]
+
+[project.optional-dependencies]
+dev = [
+    "beautifulsoup4",
+    "Jinja2",
+    "pyfakefs",
+    "pytest>=4.6",
+    "pytest-cov",
+    "sphinx",
+    "sphinx-autodoc-typehints",
+    "sphinx_rtd_theme",
+    "lxml",
+    "mdformat-myst",
+]
+
+
+notebook = [
+    "jupyter",
+]
+
+unittest_minimal = [
+]
+
+unittest = [
+    "privacy-guard[dev,notebook,unittest_minimal]",
+]
+
+tutorial = [
+    "privacy-guard[unittest]",
+    "mdformat",
+]
+
+[project.urls]
+Repository = "https://github.com/facebookresearch/PrivacyGuard"
+
+[tool.setuptools.packages]
+find = {}
+
+[tool.setuptools.package-data]
+"*" = ["*.js", "*.css", "*.html"]
+
+[tool.setuptools_scm]
+write_to = "privacy_guard/version.py"
+local_scheme = "node-and-date"
+
+[tool.usort]
+first_party_detection = false
+
+[tool.ufmt]
+formatter = "ruff-api"


### PR DESCRIPTION
Summary:
- Adding LICENSE to OSS repo (using MIT license) 
- Adds README.md file to OSS repo, with instructions to develop in the OSS environment. 
- Adds fbcode/privacy_guard/github/pyproject.toml, which will be used to build PrivacyGuard in package managers (`pip install -e .`)

Differential Revision: D82049096


