### PR TITLE
Remove compute_eps_at_tpr_threshold function from MIAResults (#39)

### DIFF
--- a/privacy_guard/analysis/mia/mia_results.py
+++ b/privacy_guard/analysis/mia/mia_results.py
@@ -299,64 +299,6 @@ class MIAResults:
 
         return accuracy, auc_value, eps_fpr_array, eps_tpr_array, eps_max_array
 
-    def compute_eps_at_tpr_threshold(
-        self,
-        delta: float,
-        tpr_threshold: NDArray[float],
-        cap_eps: bool = True,
-        verbose: bool = False,
-    ) -> list[float]:
-        """
-        Compute epsilon at error threshold for MIA attack
-        """
-
-        assert len(tpr_threshold) > 1
-
-        tpr, fpr = self.get_tpr_fpr()
-
-        fnr = 1 - tpr
-        tnr = 1 - fpr
-
-        # Divide by zero and invalid value warnings are expectd and occur at certain threshold values
-        # We suppress these warnings to avoid disruptive output logs
-        with np.errstate(divide="ignore", invalid="ignore"):
-            eps1 = np.log(1 - fnr - delta) - np.log(fpr)
-            eps2 = np.log(tnr - delta) - np.log(fnr)
-
-        # filter out extreme values in eps1 and eps2
-        if cap_eps:
-            eps_ub = np.log(self._scores_train.shape[0])
-            eps1[eps1 > eps_ub] = eps_ub
-            eps2[eps2 > eps_ub] = eps_ub
-
-        eps_tpr_array = []
-
-        tpr_array = []
-
-        # find leftmost index in tpr that is >= tpr_threshold
-        tpr_indices = self._get_indices_of_error_at_thresholds(
-            tpr, tpr_threshold, "tpr"
-        )
-
-        for i in range(len(tpr_threshold)):
-            tpr_idx = tpr_indices[i]
-            tpr_level = tpr[tpr_idx]
-            eps_tpr = eps1[tpr_idx]
-            tpr_array.append(tpr_level)
-            eps_tpr_array.append(eps_tpr)
-
-        if verbose:
-            logger.info(
-                "\n".join(
-                    [
-                        f"eps@fpr{thre}[tpr={tpr_array[i]:.3f}]: {eps_tpr_array[i]:.3f}"
-                        for i, thre in enumerate(tpr_threshold)
-                    ]
-                )
-            )
-
-        return eps_tpr_array
-
     @staticmethod
     def _clopper_pearson(
         count: int,

--- a/privacy_guard/analysis/tests/test_mia_results.py
+++ b/privacy_guard/analysis/tests/test_mia_results.py
@@ -345,15 +345,6 @@ class TestMiaResults(unittest.TestCase):
         self.assertEqual(len(eps_tpr_array), len(error_thresholds))
         self.assertEqual(len(eps_max_array), len(error_thresholds))
 
-    def test_compute_eps_at_tpr_threshold(self) -> None:
-        error_thresholds: np.ndarray = np.linspace(0.01, 1, 100)
-
-        eps_tpr_array = self.mia_results.compute_eps_at_tpr_threshold(
-            delta=0.1, tpr_threshold=error_thresholds, verbose=True
-        )
-
-        self.assertEqual(len(eps_tpr_array), len(error_thresholds))
-
     def test_suppress_divide_and_invalid_warnings(self) -> None:
         threshold = np.array([0.1, 0.2, 0.3])
         tpr = np.array([1.0, 1.0, 1.0, 0.5])
@@ -382,21 +373,6 @@ class TestMiaResults(unittest.TestCase):
             with warnings.catch_warnings(record=True) as w:
                 self.mia_results.compute_metrics_at_error_threshold(
                     delta, error_threshold=threshold
-                )
-                self.assertFalse(
-                    any("divide by zero" in str(warning.message) for warning in w)
-                )
-                self.assertFalse(
-                    any("invalid value" in str(warning.message) for warning in w)
-                )
-
-        # test that warnings are suppressed when compute_eps_at_tpr_threshold is called
-        with patch.object(MIAResults, "get_tpr_fpr") as mock_get_tpr_fpr:
-            mock_get_tpr_fpr.return_value = (tpr, fpr)
-            # Use the catch_warnings context manager to check that no warnings are raised
-            with warnings.catch_warnings(record=True) as w:
-                self.mia_results.compute_eps_at_tpr_threshold(
-                    delta=delta, tpr_threshold=threshold
                 )
                 self.assertFalse(
                     any("divide by zero" in str(warning.message) for warning in w)


### PR DESCRIPTION
Summary:

`compute_eps_at_tpr_threshold` is no longer needed as we use `compute_metrics_at_error_threshold` to compute epsilon at TPR thresholds (as well as FPR).

This allows us to run only one round of bootstrap as opposed to two boostrap runs (with TPR and with FPR errors).

Differential Revision: D82749962


