### PR TITLE
Update PrivacyGuard Attack License Headers to MIT

### DIFF
--- a/privacy_guard/attacks/base_attack.py
+++ b/privacy_guard/attacks/base_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/calib_attack.py
+++ b/privacy_guard/attacks/calib_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/extraction/generation_attack.py
+++ b/privacy_guard/attacks/extraction/generation_attack.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 import logging
 

--- a/privacy_guard/attacks/extraction/logits_attack.py
+++ b/privacy_guard/attacks/extraction/logits_attack.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 import logging
 

--- a/privacy_guard/attacks/extraction/logprobs_attack.py
+++ b/privacy_guard/attacks/extraction/logprobs_attack.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 import logging
 

--- a/privacy_guard/attacks/extraction/predictors/__init__.py
+++ b/privacy_guard/attacks/extraction/predictors/__init__.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 """
 Predictors module for privacy attacks.

--- a/privacy_guard/attacks/extraction/predictors/base_predictor.py
+++ b/privacy_guard/attacks/extraction/predictors/base_predictor.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 """
 Base predictor interface for GenAI extraction attacks.

--- a/privacy_guard/attacks/extraction/predictors/huggingface_predictor.py
+++ b/privacy_guard/attacks/extraction/predictors/huggingface_predictor.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 """
 HuggingFace predictor implementation for GenAI extraction attacks.

--- a/privacy_guard/attacks/extraction/predictors/tests/test_hf_predictor_local.py
+++ b/privacy_guard/attacks/extraction/predictors/tests/test_hf_predictor_local.py
@@ -1,6 +1,9 @@
-# pyre-strict
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# pyre-strict
 
 """
 Test script for HuggingFacePredictor generation capabilities.

--- a/privacy_guard/attacks/extraction/predictors/tests/test_huggingface_predictor.py
+++ b/privacy_guard/attacks/extraction/predictors/tests/test_huggingface_predictor.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import unittest

--- a/privacy_guard/attacks/extraction/scripts/generation.py
+++ b/privacy_guard/attacks/extraction/scripts/generation.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # pyre-strict
 
 #!/usr/bin/env python3

--- a/privacy_guard/attacks/extraction/tests/test_generation_attack.py
+++ b/privacy_guard/attacks/extraction/tests/test_generation_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import os

--- a/privacy_guard/attacks/extraction/tests/test_logits_attack.py
+++ b/privacy_guard/attacks/extraction/tests/test_logits_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import tempfile

--- a/privacy_guard/attacks/extraction/tests/test_logprobs_attack.py
+++ b/privacy_guard/attacks/extraction/tests/test_logprobs_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import tempfile

--- a/privacy_guard/attacks/extraction/utils/data_utils.py
+++ b/privacy_guard/attacks/extraction/utils/data_utils.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # pyre-strict
 
 """

--- a/privacy_guard/attacks/extraction/utils/model_inference.py
+++ b/privacy_guard/attacks/extraction/utils/model_inference.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 # pyre-strict
 
 """

--- a/privacy_guard/attacks/extraction/utils/tests/test_data_utils.py
+++ b/privacy_guard/attacks/extraction/utils/tests/test_data_utils.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import os

--- a/privacy_guard/attacks/extraction/utils/tests/test_model_inference.py
+++ b/privacy_guard/attacks/extraction/utils/tests/test_model_inference.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 import unittest

--- a/privacy_guard/attacks/lira_attack.py
+++ b/privacy_guard/attacks/lira_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 from typing import Tuple, Union

--- a/privacy_guard/attacks/loss_attack.py
+++ b/privacy_guard/attacks/loss_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/rmia_attack.py
+++ b/privacy_guard/attacks/rmia_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 from typing import Optional

--- a/privacy_guard/attacks/tests/test_calib_attack.py
+++ b/privacy_guard/attacks/tests/test_calib_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/tests/test_lira_attack.py
+++ b/privacy_guard/attacks/tests/test_lira_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/tests/test_loss_attack.py
+++ b/privacy_guard/attacks/tests/test_loss_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/tests/test_rmia_attack.py
+++ b/privacy_guard/attacks/tests/test_rmia_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/tests/test_text_inclusion_attack.py
+++ b/privacy_guard/attacks/tests/test_text_inclusion_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 

--- a/privacy_guard/attacks/text_inclusion_attack.py
+++ b/privacy_guard/attacks/text_inclusion_attack.py
@@ -1,4 +1,7 @@
-# (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
 
 # pyre-strict
 


### PR DESCRIPTION
Summary: This updates the Attack OSS files of PrivacyGuard to reflect the MIT license

Differential Revision: D82836646


