### PR TITLE
Update PACKAGE transformers library version to support gpt-oss

### DIFF
--- a/privacy_guard/attacks/extraction/predictors/huggingface_predictor.py
+++ b/privacy_guard/attacks/extraction/predictors/huggingface_predictor.py
@@ -284,7 +284,7 @@ class HuggingFacePredictor(BasePredictor):
 
         with torch.no_grad():
             # Get model outputs for the entire batch
-            outputs = (
+            outputs = (  # pyre-fixme[29]: `typing.Union[torch._tensor.Tensor, torch.nn.modules.module.Module]` is not a function.
                 self.model.module  # pyre-ignore
                 if hasattr(self.model, "module")
                 else self.model

--- a/privacy_guard/attacks/extraction/tests/test_generation_attack.py
+++ b/privacy_guard/attacks/extraction/tests/test_generation_attack.py
@@ -19,6 +19,8 @@ import unittest
 
 from unittest.mock import MagicMock
 
+import transformers
+from packaging.version import Version
 from privacy_guard.attacks.extraction.generation_attack import GenerationAttack
 
 
@@ -144,6 +146,17 @@ class TestGenerationAttack(unittest.TestCase):
 
         self.assertIn("Missing required columns", str(context.exception))
         bad_input_file.close()
+
+    def test_transformers_version_in_generation_attack(self) -> None:
+        """Verify that transformers version is greater than or equal to 4.55.0"""
+        current_version = transformers.__version__
+        required_version = "4.55.0"
+
+        self.assertGreaterEqual(
+            Version(current_version),
+            Version(required_version),
+            f"Transformers version {current_version} must be greater than or equal to 4.55.0",
+        )
 
     def tearDown(self) -> None:
         """Clean up temporary files."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,8 @@ dependencies = [
     "torch",
     'tqdm',
     'textdistance',
-    'transformers',
+    'transformers>=4.55.0',
+    'accelerate',
     'later',
 ]
 


### PR DESCRIPTION
Summary:
To unblock the tutorial PrivacyGuard Tutorial: Memorization of Online Content in LLMs, updating the transformers version to enable gpt-oss to be used. 


N8564502

Differential Revision: D86675884


