### PR TITLE
Update transformers library version to 4.57.1

### DIFF
--- a/privacy_guard/attacks/extraction/tests/test_generation_attack.py
+++ b/privacy_guard/attacks/extraction/tests/test_generation_attack.py
@@ -148,14 +148,14 @@ class TestGenerationAttack(unittest.TestCase):
         bad_input_file.close()
 
     def test_transformers_version_in_generation_attack(self) -> None:
-        """Verify that transformers version is greater than or equal to 4.55.0"""
+        """Verify that transformers version is greater than or equal to 4.57.1"""
         current_version = transformers.__version__
-        required_version = "4.55.0"
+        required_version = "4.57.1"
 
         self.assertGreaterEqual(
             Version(current_version),
             Version(required_version),
-            f"Transformers version {current_version} must be greater than or equal to 4.55.0",
+            f"Transformers version {current_version} must be greater than or equal to 4.57.1",
         )
 
     def tearDown(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "torch",
     'tqdm',
     'textdistance',
-    'transformers>=4.55.0',
+    'transformers>=4.57.1',
     'accelerate',
     'later',
 ]


### PR DESCRIPTION
Summary:
Update the transformers version from 4.55.0 to 4.57.1 in PrivacyGuard.

- Update transformers-stack version to 4.57.1 in PACKAGE files
- Update pyproject.toml to require transformers>=4.57.1
- Update bento kernel to use transformers-stack 4.57.1
- Update version check test to validate 4.57.1

This is needed to support Olmo models
"""
Installation
Olmo 3 is supported in transformers 4.57.0 or higher:

pip install transformers>=4.57.0
"""
4.57.1 is selected because version 4.57.0 exactly is not imported internally.

Reviewed By: s-huu, lucamelis

Differential Revision: D89408632


