### PR TITLE
Text Inclusion Analysis, option to remove consecutive whitespace from cleaned text

### DIFF
--- a/privacy_guard/analysis/extraction/text_inclusion_analysis_input.py
+++ b/privacy_guard/analysis/extraction/text_inclusion_analysis_input.py
@@ -50,6 +50,7 @@ class TextInclusionAnalysisInput(BaseAnalysisInput):
         lcs_bound_config: LCSBoundConfig | None = None,
         disable_word_level_longest_common_subsequence: bool = False,
         disable_char_level_longest_common_subsequence: bool = True,
+        remove_consecutive_whitespace: bool = False,
     ) -> None:
         columns = generation_df.columns.tolist()
         assert prompt_key in columns, (
@@ -77,6 +78,8 @@ class TextInclusionAnalysisInput(BaseAnalysisInput):
         self.disable_char_level_longest_common_subsequence = (
             disable_char_level_longest_common_subsequence
         )
+
+        self.remove_consecutive_whitespace = remove_consecutive_whitespace
 
         super().__init__(df_train_user=generation_df, df_test_user=pd.DataFrame())
 


### PR DESCRIPTION
Summary:
This adds supported for removing consecutive whitespace before comparing text inclusion. 

Example:
```
I ate \n the apple => I ate    the apple
```
Would not match as equal to, as the new line would map to another space. 
```
I ate the apple
```

This diff adds support for squashing consecutive whitespace after the filtering so verbatim text is matched correctly.

Differential Revision: D89493643


