### PR TITLE
Enable Pyrefly in fbcode/privacy_guard

### DIFF
--- a/privacy_guard/analysis/extraction/reference_model_comparison_node.py
+++ b/privacy_guard/analysis/extraction/reference_model_comparison_node.py
@@ -104,9 +104,13 @@ class ReferenceModelComparisonNode(BaseAnalysisNode):
 
         outputs = ReferenceModelComparisonNodeOutput(
             num_samples=len(target_df),
+            # pyrefly: ignore [bad-argument-type]
             tgt_pos_ref_pos=target_df["tgt_pos_ref_pos"],
+            # pyrefly: ignore [bad-argument-type]
             tgt_pos_ref_neg=target_df["tgt_pos_ref_neg"],
+            # pyrefly: ignore [bad-argument-type]
             tgt_neg_ref_pos=target_df["tgt_neg_ref_pos"],
+            # pyrefly: ignore [bad-argument-type]
             tgt_neg_ref_neg=target_df["tgt_neg_ref_neg"],
             augmented_output_dataset=target_df,
         )

--- a/privacy_guard/analysis/lia/lia_analysis_input.py
+++ b/privacy_guard/analysis/lia/lia_analysis_input.py
@@ -22,11 +22,17 @@ from privacy_guard.analysis.base_analysis_input import BaseAnalysisInput
 class LIAAnalysisInput(BaseAnalysisInput):
     def __init__(
         self,
+        # pyrefly: ignore [bad-specialization]
         predictions: NDArray[float],
+        # pyrefly: ignore [bad-specialization]
         predictions_y1_generation: NDArray[float],
+        # pyrefly: ignore [bad-specialization]
         true_bits: NDArray[int],
+        # pyrefly: ignore [bad-specialization]
         y0: NDArray[int],
+        # pyrefly: ignore [bad-specialization]
         y1: NDArray[int],
+        # pyrefly: ignore [bad-specialization]
         received_labels: NDArray[int],
     ) -> None:
         """

--- a/privacy_guard/analysis/lia/lia_analysis_node.py
+++ b/privacy_guard/analysis/lia/lia_analysis_node.py
@@ -125,8 +125,11 @@ class LIAAnalysisNode(AnalysisNode):
             Tuple[torch.Tensor, torch.Tensor]: scores for samples with training labels and reconstructed labels
         """
 
+        # pyrefly: ignore [missing-attribute]
         received_labels = self._analysis_input.received_labels[i]
+        # pyrefly: ignore [missing-attribute]
         y1_probs = self._analysis_input.predictions_y1_generation
+        # pyrefly: ignore [missing-attribute]
         predictions = self._analysis_input.predictions
 
         if self.score_computation_function is not None:
@@ -142,6 +145,7 @@ class LIAAnalysisNode(AnalysisNode):
                 np.log(prob_train + 1e-8) - np.log(prob_reconstruct + 1e-8)
             ) * prob_diff_label**self._power
 
+        # pyrefly: ignore [missing-attribute]
         true_bits = self._analysis_input.true_bits[i]
         scores_train = torch.tensor(scores[true_bits == 0])
         scores_test = torch.tensor(scores[true_bits == 1])
@@ -152,7 +156,9 @@ class LIAAnalysisNode(AnalysisNode):
         """Run LIA analysis"""
 
         error_thresholds = np.linspace(0.01, 1, 100)
+        # pyrefly: ignore [missing-attribute]
         num_resampling = self._analysis_input.y1.shape[0]
+        # pyrefly: ignore [missing-attribute]
         num_samples = self._analysis_input.y1.shape[1]
 
         # run analysis for each game instance
@@ -221,9 +227,12 @@ class LIAAnalysisNode(AnalysisNode):
             eps_at_tpr_bounds=(list(eps_tpr_lb), list(eps_tpr_ub)),
             eps_at_fpr_bounds=(list(eps_fpr_lb), list(eps_fpr_ub)),
             data_size=num_samples,
+            # pyrefly: ignore [missing-attribute]
             label_mean=np.mean(self._analysis_input.y0),
+            # pyrefly: ignore [missing-attribute]
             prediction_mean=np.mean(self._analysis_input.predictions),
             prediction_y1_generation_mean=np.mean(
+                # pyrefly: ignore [missing-attribute]
                 self._analysis_input.predictions_y1_generation
             ),
         )

--- a/privacy_guard/analysis/mia/analysis_node.py
+++ b/privacy_guard/analysis/mia/analysis_node.py
@@ -236,7 +236,10 @@ class AnalysisNode(BaseAnalysisNode):
 
     @staticmethod
     def _compute_ci(
-        array: NDArray[float], axis: int = 0, use_one_sided_ci_ub: bool = False
+        # pyrefly: ignore [bad-specialization]
+        array: NDArray[float],
+        axis: int = 0,
+        use_one_sided_ci_ub: bool = False,
     ) -> tuple[NDArray, NDArray]:
         """Compute confidence intervals (used for eps, auc, accuracy)"""
         # Sort along the specified axis
@@ -275,6 +278,7 @@ class AnalysisNode(BaseAnalysisNode):
         Returns:
             A list of indexes (with duplicates)
         """
+        # pyrefly: ignore [bad-return]
         return np.random.randint(0, num_users, sample_size)
 
     def run_analysis(self) -> BaseAnalysisOutput:

--- a/privacy_guard/analysis/mia/fpr_lower_bound_analysis_node.py
+++ b/privacy_guard/analysis/mia/fpr_lower_bound_analysis_node.py
@@ -65,6 +65,7 @@ class FPRLowerBoundAnalysisNodeOutput(BaseAnalysisOutput):
 
 
 def compute_metric_mean_with_ci(
+    # pyrefly: ignore [bad-specialization]
     metric_array: NDArray[float],
 ) -> tuple[float, float, float]:
     # TODO: Identify descriptive values for mean, lb, ub when bootstrap fails
@@ -181,6 +182,7 @@ class FPRLowerBoundAnalysisNode(AnalysisNode):
 
         return outputs
 
+    # pyrefly: ignore [bad-specialization]
     def _make_acc_auc_epsilon_array(self) -> NDArray[float]:
         """
         Make list of tuples metrics at error thresholds, each of which contains the

--- a/privacy_guard/analysis/mia/mia_results.py
+++ b/privacy_guard/analysis/mia/mia_results.py
@@ -41,9 +41,12 @@ class MIAResults:
 
     def _get_indices_of_error_at_thresholds(
         self,
+        # pyrefly: ignore [bad-specialization]
         error_rates: NDArray[float],
+        # pyrefly: ignore [bad-specialization]
         error_thresholds: NDArray[float],
         error_type: str,
+        # pyrefly: ignore [bad-specialization]
     ) -> NDArray[int]:
         """
         Get indices where error values are greater/smaller than error thresholds.
@@ -80,6 +83,7 @@ class MIAResults:
         else:
             raise ValueError(f"Invalid error type: {error_type}")
 
+    # pyrefly: ignore [bad-specialization]
     def get_tpr_fpr(self) -> tuple[NDArray[float], NDArray[float]]:
         """
         Computes true positive rate and true negative rate given scores and labels indicating membership.
@@ -213,6 +217,7 @@ class MIAResults:
     def compute_metrics_at_error_threshold(
         self,
         delta: float,
+        # pyrefly: ignore [bad-specialization]
         error_threshold: NDArray[float],
         cap_eps: bool = True,
         verbose: bool = False,

--- a/privacy_guard/analysis/mia/parallel_analysis_node.py
+++ b/privacy_guard/analysis/mia/parallel_analysis_node.py
@@ -123,6 +123,7 @@ class ParallelAnalysisNode(AnalysisNode):
                 f"An exception occurred when computing acc/auc/epsilon metrics: {e}"
             )
 
+        # pyrefly: ignore [bad-return]
         return metrics_results
 
     def _parallel_compute_chunk_sizes(self, task_num: int) -> list[int]:

--- a/privacy_guard/analysis/mia/parallel_fpr_lower_bound_analysis_node.py
+++ b/privacy_guard/analysis/mia/parallel_fpr_lower_bound_analysis_node.py
@@ -128,6 +128,7 @@ class ParallelFPRLowerBoundAnalysisNode(FPRLowerBoundAnalysisNode):
                 f"An exception occurred when computing acc/auc/epsilon metrics: {e}"
             )
 
+        # pyrefly: ignore [bad-return]
         return metrics_results, eps_fpr_results
 
     def _parallel_compute_chunk_sizes(self, task_num: int) -> list[int]:

--- a/privacy_guard/analysis/scripts/probabilistic_memorization_analysis.py
+++ b/privacy_guard/analysis/scripts/probabilistic_memorization_analysis.py
@@ -30,6 +30,7 @@ tqdm.pandas()
 def dump_augmented_df(df: pd.DataFrame, jsonl_output_path: str) -> None:
     jsonl_data = df.to_json(orient="records", lines=True)
     with open(jsonl_output_path, "w") as f:
+        # pyrefly: ignore [bad-argument-type]
         f.write(jsonl_data)
 
 

--- a/privacy_guard/analysis/scripts/reference_model_comparison.py
+++ b/privacy_guard/analysis/scripts/reference_model_comparison.py
@@ -32,6 +32,7 @@ def dump_augmented_df(df: pd.DataFrame, jsonl_output_path: str) -> None:
     jsonl_data = df.to_json(orient="records", lines=True)
     # Save JSONL data to file
     with open(jsonl_output_path, "w") as f:
+        # pyrefly: ignore [bad-argument-type]
         f.write(jsonl_data)
 
 

--- a/privacy_guard/analysis/scripts/tests/test_reference_model_comparison_script.py
+++ b/privacy_guard/analysis/scripts/tests/test_reference_model_comparison_script.py
@@ -40,6 +40,7 @@ class TestReferenceModelComparisonScript(unittest.TestCase):
             prefix="test_target", suffix=".jsonl", mode="w"
         )
         self.temp_target_file_name = self.temp_target_file.name
+        # pyrefly: ignore [no-matching-overload]
         self.temp_target_file.write(
             pd.DataFrame(self.target_data).to_json(orient="records", lines=True)
         )
@@ -50,6 +51,7 @@ class TestReferenceModelComparisonScript(unittest.TestCase):
             prefix="test_reference", suffix=".jsonl", mode="w"
         )
         self.temp_reference_file_name = self.temp_reference_file.name
+        # pyrefly: ignore [no-matching-overload]
         self.temp_reference_file.write(
             pd.DataFrame(self.reference_data).to_json(orient="records", lines=True)
         )
@@ -112,6 +114,7 @@ class TestReferenceModelComparisonScript(unittest.TestCase):
             prefix="test_target_custom", suffix=".jsonl", mode="w"
         )
         temp_target_file_name = temp_target_file.name
+        # pyrefly: ignore [no-matching-overload]
         temp_target_file.write(
             pd.DataFrame(target_data).to_json(orient="records", lines=True)
         )
@@ -122,6 +125,7 @@ class TestReferenceModelComparisonScript(unittest.TestCase):
             prefix="test_reference_custom", suffix=".jsonl", mode="w"
         )
         temp_reference_file_name = temp_reference_file.name
+        # pyrefly: ignore [no-matching-overload]
         temp_reference_file.write(
             pd.DataFrame(reference_data).to_json(orient="records", lines=True)
         )

--- a/privacy_guard/analysis/scripts/tests/test_text_inclusion_metrics.py
+++ b/privacy_guard/analysis/scripts/tests/test_text_inclusion_metrics.py
@@ -82,6 +82,7 @@ class TestTextInclusionScript(unittest.TestCase):
             prefix="test_input", suffix=".jsonl", mode="w"
         )
         self.temp_input_file_name = self.temp_input_file.name
+        # pyrefly: ignore [no-matching-overload]
         self.temp_input_file.write(
             pd.DataFrame(self.data).to_json(orient="records", lines=True)
         )
@@ -92,6 +93,7 @@ class TestTextInclusionScript(unittest.TestCase):
             prefix="test_input", suffix=".jsonl", mode="w"
         )
         self.temp_sft_input_file_name = self.temp_sft_input_file.name
+        # pyrefly: ignore [no-matching-overload]
         self.temp_sft_input_file.write(
             pd.DataFrame(self.sft_data).to_json(orient="records", lines=True)
         )

--- a/privacy_guard/analysis/scripts/text_inclusion_metrics.py
+++ b/privacy_guard/analysis/scripts/text_inclusion_metrics.py
@@ -189,6 +189,7 @@ def dump_augmented_df(df: pd.DataFrame, jsonl_output_path: str) -> None:
     jsonl_data = df.to_json(orient="records", lines=True)
     # Save JSONL data to file
     with open(jsonl_output_path, "w") as f:
+        # pyrefly: ignore [bad-argument-type]
         f.write(jsonl_data)
 
 

--- a/privacy_guard/analysis/tests/base_test_analysis_node.py
+++ b/privacy_guard/analysis/tests/base_test_analysis_node.py
@@ -92,6 +92,7 @@ class BaseTestAnalysisNode(unittest.TestCase):
         super().setUp()
 
     def get_long_dataframes(self) -> Tuple[pd.DataFrame, pd.DataFrame]:
+        # pyrefly: ignore [bad-argument-type]
         np.random.seed(0)
         df_train_user_long = self.sample_normal_distribution(0.5, 0.1, 10000)
         df_test_user_long = self.sample_normal_distribution(0.5, 0.1, 10000)

--- a/privacy_guard/analysis/tests/test_analysis_node.py
+++ b/privacy_guard/analysis/tests/test_analysis_node.py
@@ -458,6 +458,7 @@ class TestAnalysisNode(BaseTestAnalysisNode):
     def test_use_fnr_tnr_parameter_comparison(self) -> None:
         """Test comparison between use_fnr_tnr=False and use_fnr_tnr=True"""
         # Set random seed to ensure deterministic bootstrap sampling
+        # pyrefly: ignore [bad-argument-type]
         np.random.seed(42)
 
         # Test with use_fnr_tnr=False
@@ -472,6 +473,7 @@ class TestAnalysisNode(BaseTestAnalysisNode):
         outputs_false = analysis_node_false.compute_outputs()
 
         # Reset seed to ensure same bootstrap sampling for the second run
+        # pyrefly: ignore [bad-argument-type]
         np.random.seed(42)
 
         # Test with use_fnr_tnr=True

--- a/privacy_guard/analysis/tests/test_lia_analysis_node.py
+++ b/privacy_guard/analysis/tests/test_lia_analysis_node.py
@@ -34,6 +34,7 @@ class TestLIAAnalysisNode(unittest.TestCase):
         self.num_resampling = 5
 
         # Generate base data
+        # pyrefly: ignore [bad-argument-type]
         np.random.seed(42)  # For reproducible tests
         self.predictions = np.random.uniform(0.1, 0.9, self.num_samples)
         self.y1_preds = np.random.uniform(0.1, 0.9, self.num_samples)

--- a/privacy_guard/attacks/code_similarity/code_bleu_attack.py
+++ b/privacy_guard/attacks/code_similarity/code_bleu_attack.py
@@ -139,7 +139,9 @@ class CodeBleuAttack(BaseAttack):
                 if lang not in AVAILABLE_LANGS:
                     raise ValueError(f"Language {lang} not supported by CodeBLEU.")
                 tree_sitter_language = Language(
-                    importlib.resources.files("codebleu") / "my-languages.so", lang
+                    # pyrefly: ignore [bad-argument-type]
+                    importlib.resources.files("codebleu") / "my-languages.so",
+                    lang,
                 )
                 # pyre-ignore[16]: Module `tree_sitter` has no attribute `Parser`.
                 parser = Parser()

--- a/privacy_guard/attacks/code_similarity/py_tree_sitter_attack.py
+++ b/privacy_guard/attacks/code_similarity/py_tree_sitter_attack.py
@@ -70,7 +70,9 @@ def _get_parser(language: str) -> Parser:  # pyre-ignore[11]
             f"Unsupported language '{language}'. Supported: {sorted(AVAILABLE_LANGS)}"
         )
     ts_language = Language(
-        importlib.resources.files("codebleu") / "my-languages.so", lang_key
+        # pyrefly: ignore [bad-argument-type]
+        importlib.resources.files("codebleu") / "my-languages.so",
+        lang_key,
     )
     # pyre-ignore[16]: Module `tree_sitter` has no attribute `Parser`.
     parser = Parser()

--- a/privacy_guard/attacks/extraction/predictors/gpt_oss_predictor.py
+++ b/privacy_guard/attacks/extraction/predictors/gpt_oss_predictor.py
@@ -102,7 +102,9 @@ class GPTOSSPredictor(HuggingFacePredictor):
                 raise Warning(f"Found non-string item in batch: {type(item)}")
                 clean_batch.append(str(item) if item is not None else "")
             else:
+                # pyrefly: ignore [bad-argument-type]
                 clean_batch.append({"role": "user", "content": item})
+        # pyrefly: ignore [bad-return]
         return clean_batch
 
     # Override

--- a/privacy_guard/attacks/extraction/utils/tests/test_data_utils.py
+++ b/privacy_guard/attacks/extraction/utils/tests/test_data_utils.py
@@ -40,6 +40,7 @@ class TestDataUtils(unittest.TestCase):
                 Callable[[pd.DataFrame, str], None],
                 Callable[[str], pd.DataFrame],
             ]
+            # pyrefly: ignore [bad-assignment]
         ] = [
             (
                 "jsonl",

--- a/privacy_guard/attacks/tests/test_code_bleu_attack.py
+++ b/privacy_guard/attacks/tests/test_code_bleu_attack.py
@@ -35,7 +35,9 @@ from tree_sitter import (  # @manual=fbsource//third-party/pypi/tree-sitter:tree
 # pyre-ignore[11]: Annotation `Parser` is not defined as a type
 def _make_parser(language: str) -> Parser:
     tree_sitter_language = Language(
-        importlib.resources.files("codebleu") / "my-languages.so", language
+        # pyrefly: ignore [bad-argument-type]
+        importlib.resources.files("codebleu") / "my-languages.so",
+        language,
     )
     # pyre-ignore[16]: Module `tree_sitter` has no attribute `Parser`
     parser = Parser()

--- a/privacy_guard/attacks/tests/test_lia_attack.py
+++ b/privacy_guard/attacks/tests/test_lia_attack.py
@@ -281,6 +281,7 @@ class TestLIAAttack(unittest.TestCase):
 
         predictions_y1 = lia_attack.get_y1_predictions(df_with_reference)
 
+        # pyrefly: ignore [missing-attribute]
         expected_predictions = df_with_reference["predictions_reference"].values
         self.assertEqual(len(predictions_y1), len(expected_predictions))
         assert_array_equal(predictions_y1, expected_predictions)
@@ -300,6 +301,7 @@ class TestLIAAttack(unittest.TestCase):
         self.assertEqual(len(predictions_y1), len(df_attack))
         assert_almost_equal(
             predictions_y1,
+            # pyrefly: ignore [missing-attribute]
             0.7 * df_attack["predictions_y1_target"].values
             + 0.3 * df_attack["predictions_calib"].values,
         )
@@ -526,6 +528,7 @@ class TestLIAAttack(unittest.TestCase):
         )
         assert_array_equal(analysis_input.predictions, df_attack["predictions"].values)
         expected_predictions_y1_generation = (
+            # pyrefly: ignore [missing-attribute]
             0.7 * df_attack["predictions_y1_target"].values
             + 0.3 * df_attack["predictions_calib"].values
         )

--- a/privacy_guard/attacks/tests/test_lira_attack.py
+++ b/privacy_guard/attacks/tests/test_lira_attack.py
@@ -66,12 +66,15 @@ class TestLiraAttack(unittest.TestCase):
             "score_std_in": {"0": 0.1, "1": 0.15, "2": 0.2, "3": 0.25, "4": 0.3},
             "score_std_out": {"0": 0.05, "1": 0.1, "2": 0.15, "3": 0.2, "4": 0.25},
         }
+        # pyrefly: ignore [bad-assignment]
         self.df_train_merge = pd.DataFrame.from_dict(self.df_train_merge)
 
         self.user_id_key = "user_id"
 
         self.lira_attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             use_fixed_variance=True,
@@ -79,7 +82,9 @@ class TestLiraAttack(unittest.TestCase):
         )
 
         self.lira_attack_no_fixed_variance = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             use_fixed_variance=False,
@@ -108,7 +113,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='global'"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="global",
@@ -122,7 +129,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected standard deviation of all score_orig values
         expected_std = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_orig,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_orig,  # df_test_merge is same as df_train_merge in this test
             ]
         ).std()
@@ -137,7 +146,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='shadows_in' and online_attack=False"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="shadows_in",
@@ -152,7 +163,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected mean of all score_std values
         expected_std = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std,  # df_test_merge is same as df_train_merge in this test
             ]
         ).mean()
@@ -167,7 +180,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='shadows_in' and online_attack=True"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="shadows_in",
@@ -182,7 +197,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected mean of all score_std_in values
         expected_std = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_in,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_in,  # df_test_merge is same as df_train_merge in this test
             ]
         ).mean()
@@ -197,7 +214,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='shadows_out' and online_attack=False"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="shadows_out",
@@ -212,7 +231,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected mean of all score_std values
         expected_std = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std,  # df_test_merge is same as df_train_merge in this test
             ]
         ).mean()
@@ -227,7 +248,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='shadows_out' and online_attack=True"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="shadows_out",
@@ -242,7 +265,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected mean of all score_std_out values
         expected_std = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_out,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_out,  # df_test_merge is same as df_train_merge in this test
             ]
         ).mean()
@@ -257,7 +282,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='mix' and online_attack=True"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="mix",
@@ -272,7 +299,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected mean of all score_std_in values for std_in
         expected_std_in = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_in,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_in,  # df_test_merge is same as df_train_merge in this test
             ]
         ).mean()
@@ -280,7 +309,9 @@ class TestLiraAttack(unittest.TestCase):
         # Calculate expected mean of all score_std_out values for std_out
         expected_std_out = pd.concat(
             [
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_out,
+                # pyrefly: ignore [missing-attribute]
                 self.df_train_merge.score_std_out,  # df_test_merge is same as df_train_merge in this test
             ]
         ).mean()
@@ -295,7 +326,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with std_dev_type='mix' and online_attack=False raises ValueError"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="mix",
@@ -316,7 +349,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test _get_std_dev with invalid std_dev_type raises ValueError"""
         # Setup
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             std_dev_type="invalid_type",
@@ -333,11 +368,15 @@ class TestLiraAttack(unittest.TestCase):
         """Test that run_attack drops rows with NaN values in df_train_merge after logpdf computation."""
         # Setup: create training data with NaN in score_orig so logpdf produces NaN
         df_train_with_nan = self.df_train_merge.copy()
+        # pyrefly: ignore [missing-attribute]
         df_train_with_nan.loc["0", "score_orig"] = np.nan
+        # pyrefly: ignore [missing-attribute]
         df_train_with_nan.loc["2", "score_orig"] = np.nan
 
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=df_train_with_nan,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             use_fixed_variance=True,
@@ -358,10 +397,13 @@ class TestLiraAttack(unittest.TestCase):
         """Test that run_attack drops rows with NaN values in df_test_merge after logpdf computation."""
         # Setup: create test data with NaN in score_orig so logpdf produces NaN
         df_test_with_nan = self.df_train_merge.copy()
+        # pyrefly: ignore [missing-attribute]
         df_test_with_nan.loc["1", "score_orig"] = np.nan
 
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=df_test_with_nan,
             row_aggregation=AggregationType.MAX,
             use_fixed_variance=True,
@@ -381,11 +423,15 @@ class TestLiraAttack(unittest.TestCase):
         """Test that run_attack drops NaN rows for online attack mode."""
         # Setup: create data with NaN in score_mean_in to produce NaN in logpdf
         df_train_with_nan = self.df_train_merge.copy()
+        # pyrefly: ignore [missing-attribute]
         df_train_with_nan.loc["0", "score_mean_in"] = np.nan
+        # pyrefly: ignore [missing-attribute]
         df_train_with_nan.loc["3", "score_mean_out"] = np.nan
 
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=df_train_with_nan,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             use_fixed_variance=True,
@@ -406,7 +452,9 @@ class TestLiraAttack(unittest.TestCase):
         """Test that run_attack preserves all rows when no NaN values are present."""
         # Setup: use clean data (no NaN)
         attack = LiraAttack(
+            # pyrefly: ignore [bad-argument-type]
             df_train_merge=self.df_train_merge,
+            # pyrefly: ignore [bad-argument-type]
             df_test_merge=self.df_train_merge,
             row_aggregation=AggregationType.MAX,
             use_fixed_variance=True,

--- a/privacy_guard/shadow_model_training/dataset.py
+++ b/privacy_guard/shadow_model_training/dataset.py
@@ -184,6 +184,7 @@ def create_shadow_datasets(
     Returns:
         List of (train_subsets, keep) tuples for each shadow model and the target model
     """
+    # pyrefly: ignore [bad-argument-type]
     np.random.seed(seed)
     dataset_size = len(cast(Sized, train_dataset))
 

--- a/privacy_guard/shadow_model_training/tests/test_dataset.py
+++ b/privacy_guard/shadow_model_training/tests/test_dataset.py
@@ -39,6 +39,7 @@ class MockCIFAR10(Dataset):
     def __len__(self) -> int:
         return self.size
 
+    # pyrefly: ignore [bad-override-param-name]
     def __getitem__(self, idx: int) -> tuple[torch.Tensor, torch.Tensor]:
         return self.data[idx], self.targets[idx]
 

--- a/privacy_guard/shadow_model_training/tests/test_training.py
+++ b/privacy_guard/shadow_model_training/tests/test_training.py
@@ -109,6 +109,7 @@ class TestTraining(unittest.TestCase):
         self.assertIsInstance(logits, np.ndarray)
 
         # The shape should be (num_samples, 1) since we're returning likelihood ratios
+        # pyrefly: ignore [bad-argument-type]
         expected_samples = len(self.test_loader.dataset)
         self.assertEqual(logits.shape, (expected_samples, 1))
 
@@ -182,6 +183,7 @@ class TestTraining(unittest.TestCase):
 
         # Check that scores is a numpy array with the expected shape
         self.assertIsInstance(scores, np.ndarray)
+        # pyrefly: ignore [bad-argument-type]
         expected_samples = len(self.test_loader.dataset)
         self.assertEqual(scores.shape, (expected_samples,))
 


### PR DESCRIPTION
Summary:
Automated migration to enable Pyrefly type checking for `fbcode/privacy_guard`.

- Added `python.set_pyrefly(True)` to PACKAGE file
- Suppressed pre-existing type errors

Pyrefly is Meta's next-generation Python type checker, replacing Pyre.

If you encounter issues, you can revert the PACKAGE change by removing
the `python.set_pyrefly(True)` line.
#pyreupgrade

Differential Revision: D108312457


